### PR TITLE
[TC-5716] Make priceInBaseCurrency mandatory in order integration API

### DIFF
--- a/buyer/issue/README.md
+++ b/buyer/issue/README.md
@@ -118,8 +118,8 @@ The `supplierAccountNumber` should be set on forehand in the Tradecloud connecti
 #### Requested prices
 
 * `lines.prices`: the requested price. Advised is to provide only `netPrice` for its simplicity, used by most buyers, or alternatively `grossPrice` together with `discountPercentage`. 
-* `priceInLocalCurrency`: at least provide a price in the local currency of the supplier, like `CNY` in China.
-* `priceInBaseCurrency`: if available provide a price in your base currency, like `EUR` in the EU.
+* `priceInLocalCurrency`: provide a price in the local currency of the supplier, like `CNY` in China.
+* `priceInBaseCurrency`: provide a price in your base currency, like `EUR` in the EU.
 * `value`: the price value has a decimal `1234.56` format with any number of digits.
 * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
 * `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.


### PR DESCRIPTION
## Description
https://tradecloud.atlassian.net/browse/TC-5716

### Scope
This PR creates and uses a separate Price model only to be used by the order integration API.

### Submitter pre-flight check
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
