### PR TITLE
[TC-6430] Add orders indicators API

### DIFF
--- a/buyer/approve-proposal.md
+++ b/buyer/approve-proposal.md
@@ -9,4 +9,3 @@ It is not possible to use the API connector to approve a order line proposal.
 Also the webhook is not triggered in case of a order line proposal by the supplier.  
 If you need this, send a request to support.
 {% endhint %}
-

--- a/buyer/cancel.md
+++ b/buyer/cancel.md
@@ -10,9 +10,9 @@ Cancel an order line in Tradecloud when it is cancelled at the buyer.
 - `Completed` lines cannot be cancelled
 - `Cancelled` lines cannot be cancelled again
 
-## Cancelling by resending an order
+## Cancelling by resending an order using the `/order` API
 
-The order or line can be cancelled by setting `indicators.cancelled` on either order or line level and updating the order.
+The order or line can be cancelled by setting `indicators.cancelled` on either order or line level and updating the order using the `/order` API resource.
 
 {% hint style="info" %}
 If you provide a `cancelled` indicator on order level, **ONLY** the lines provided in this order message will be cancelled.
@@ -22,9 +22,9 @@ If you also provide a `cancelled` indicator on line level, it has **precedence**
 
 {% page-ref page="update.md" %}
 
-## Cancelling by sending the cancelled indicator
+## Cancelling by sending the cancelled indicator using the `/order/indicators` API
 
-The order or can be cancelled by setting `indicators.cancelled` on either order or line level and sending this indicator only.
+The order or can be cancelled by setting `indicators.cancelled` on either order or line level and sending this indicator only, using the `/order/indicators` API resource.
 
 {% hint style="info" %}
 If you provide a `cancelled` indicator on order level, **ALL** the lines in the order will be cancelled.

--- a/buyer/cancel.md
+++ b/buyer/cancel.md
@@ -29,7 +29,7 @@ The order or can be cancelled by setting `indicators.cancelled` on either order 
 {% hint style="info" %}
 If you provide a `cancelled` indicator on order level, **ALL** the lines in the order will be cancelled.
 
-If you also provide a compl`cancelled`eted indicator on line level, it has **precedence**  over the order level `cancelled` indicator.
+If you also provide a `cancelled` indicator on line level, it has **precedence**  over the order level `cancelled` indicator.
 {% endhint %}
 
 {% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}

--- a/buyer/cancel.md
+++ b/buyer/cancel.md
@@ -7,7 +7,7 @@ description: How to request the supplier to cancel an order or line
 Cancel an order line in Tradecloud when it is cancelled at the buyer.
 
 - `Issued`, `In Progress`, `Rejected` and `Confirmed` lines will become `Cancelled` immediately (without request)
-- `Completed` lines cannot be completed
+- `Completed` lines cannot be cancelled
 - `Cancelled` lines cannot be cancelled again
 
 ## Cancelling by resending an order
@@ -22,7 +22,7 @@ If you also provide a `cancelled` indicator on line level, it has **precedence**
 
 {% page-ref page="update.md" %}
 
-## Cancelling by sending the complete indicator
+## Cancelling by sending the cancelled indicator
 
 The order or can be cancelled by setting `indicators.cancelled` on either order or line level and sending this indicator only.
 
@@ -34,7 +34,7 @@ If you also provide a compl`cancelled`eted indicator on line level, it has **pre
 
 {% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}
 {% api-method-summary %}
-Send order by buyer
+Send order indicators by buyer
 {% endapi-method-summary %}
 
 {% api-method-description %}

--- a/buyer/cancel.md
+++ b/buyer/cancel.md
@@ -2,21 +2,89 @@
 description: How to request the supplier to cancel an order or line
 ---
 
-# Cancel an order
+# Cancelling an order or line
 
-If a purchase order line is `Issued` , `In Progress`, `Confirmed`or `Rejected` the buyer may `cancel` the line immediately.
+Cancel an order line in Tradecloud when it is cancelled at the buyer.
 
-The buyer can cancel by setting `indicators.cancel`on either order or line level and update the order.
+- `Issued`, `In Progress`, `Rejected` and `Confirmed` lines will become `Cancelled` immediately (without request)
+- `Completed` lines cannot be completed
+- `Cancelled` lines cannot be cancelled again
+
+## Cancelling by resending an order
+
+The order or line can be cancelled by setting `indicators.cancelled` on either order or line level and updating the order.
+
+{% hint style="info" %}
+If you provide a `cancelled` indicator on order level, **ONLY** the lines provided in this order message will be cancelled.
+
+If you also provide a `cancelled` indicator on line level, it has **precedence** over the order level `cancelled` indicator.
+{% endhint %}
 
 {% page-ref page="update.md" %}
 
-{% hint style="warning" %}
-You cannot cancel a`Cancelled` or`Completed` line
-{% endhint %}
+## Cancelling by sending the complete indicator
+
+The order or can be cancelled by setting `indicators.cancelled` on either order or line level and sending this indicator only.
 
 {% hint style="info" %}
-Order lines having process status `Issued, In Progress, Confirmed` or `Rejected` will become `Cancelled`
+If you provide a `cancelled` indicator on order level, **ALL** the lines in the order will be cancelled.
+
+If you also provide a compl`cancelled`eted indicator on line level, it has **precedence**  over the order level `cancelled` indicator.
 {% endhint %}
 
+{% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}
+{% api-method-summary %}
+Send order by buyer
+{% endapi-method-summary %}
 
+{% api-method-description %}
 
+{% endapi-method-description %}
+
+{% api-method-spec %}
+{% api-method-request %}
+{% api-method-headers %}
+{% api-method-parameter name="Authorization" type="string" required=true %}
+Bearer Access-Token
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="Content-Type" type="string" required=true %}
+application/json
+{% endapi-method-parameter %}
+{% endapi-method-headers %}
+
+{% api-method-body-parameters %}
+{% api-method-parameter name="body" type="object" required=true %}
+{% endapi-method-parameter %}
+{% endapi-method-body-parameters %}
+{% endapi-method-request %}
+
+{% api-method-response %}
+{% api-method-response-example httpCode=200 %}
+{% endapi-method-response %}
+{% endapi-method-spec %}
+{% endapi-method %}
+
+Body example:
+```
+{
+  "order": {
+    "purchaseOrderNumber": "PO123456789",
+    "indicators": {
+      "cancelled": true
+    }
+  },
+  "lines": [
+    {
+      "position": "0001",
+      "indicators": {
+        "cancelled": true
+      }
+    }
+  ]
+}
+```
+
+{% hint style="info" %}
+[Send order indicators OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)
+{% endhint %}

--- a/buyer/complete.md
+++ b/buyer/complete.md
@@ -2,9 +2,9 @@
 description: How to complete an order or line
 ---
 
-# Complete an order
+# Complete an order or line
 
-Complete an order line when it is completely handled at the buyer, usually when the supplier invoice is received and approved by buyer.
+Complete an order line in Tradecloud when it is completely handled at the buyer, usually when the supplier invoice is received and approved by buyer.
 
 - `Issued`, `Rejected` and `Confirmed` lines will become `Completed`
 - `In progress` and `Cancelled` lines cannot be completed
@@ -15,19 +15,21 @@ Complete an order line when it is completely handled at the buyer, usually when 
 The order or line can be marked as completed by setting `indicators.completed` on either order or line level and updating the order.
 
 {% hint style="info" %}
-If you provide a completed indicator on order level, ONLY the lines provided in this order message will be completed.
-If you also provide a completed indicator on line level, it has precedence over the order level completed indicator.
+If you provide a `completed` indicator on order level, **ONLY** the lines provided in this order message will be completed.
+
+If you also provide a `completed` indicator on line level, it has **precedence** over the order level `completed` indicator.
 {% endhint %}
 
 {% page-ref page="update.md" %}
 
 ## Completing by sending the complete indicator
 
-The order or can be marked as completed by setting `indicators.completed` on either order or line level and sending the indicator only.
+The order or line can be marked as completed by setting `indicators.completed` on either order or line level and sending this indicator only.
 
 {% hint style="info" %}
-If you provide a completed indicator on order level, ALL the lines in the order will be completed.
-If you also provide a completed indicator on line level, it has precedence over the order level completed indicator.
+If you provide a `completed` indicator on order level, **ALL** the lines in the order will be completed.
+
+If you also provide a `completed` indicator on line level, it has **precedence** over the order level `completed` indicator.
 {% endhint %}
 
 {% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}
@@ -82,7 +84,6 @@ Body example:
   ]
 }
 ```
-
 
 {% hint style="info" %}
 [Send order indicators OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)

--- a/buyer/complete.md
+++ b/buyer/complete.md
@@ -5,14 +5,81 @@ description: How to complete an order or line
 # Complete an order
 
 {% hint style="warning" %}
-This feature is planned. 
+This feature is planned.
 {% endhint %}
 
-When an order or line is completely handled at the buyer, usually when the supplier invoice is received and approved by buyer, . 
+When an order or line is completely handled at the buyer, usually when the supplier invoice is received and approved by buyer.
 
-The order or line can be marked as completed by setting `indicators.completed`on either order or line level and update the order:
+## Completing by resending an order
+
+The order or line can be marked as completed by setting `indicators.completed`on either order or line level and updating the order.
+
+{% hint style="info" %}
+If you provide a completed indicator on order level, ONLY the lines provided in this order message will be completed.
+{% endhint %}
 
 {% page-ref page="update.md" %}
+
+## Completing by sending the complete indicator
+
+The order or can be marked as competed  by setting `indicators.completed`on either order or line level and sending the indicator only.
+
+{% hint style="info" %}
+If you provide a completed indicator on order level, ALL the lines in the order will be completed, regardless the lines provided in this order indicators message.
+{% endhint %}
+
+{% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}
+{% api-method-summary %}
+Send order by buyer
+{% endapi-method-summary %}
+
+{% api-method-description %}
+
+{% endapi-method-description %}
+
+{% api-method-spec %}
+{% api-method-request %}
+{% api-method-headers %}
+{% api-method-parameter name="Authorization" type="string" required=true %}
+Bearer Access-Token
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="Content-Type" type="string" required=true %}
+application/json
+{% endapi-method-parameter %}
+{% endapi-method-headers %}
+
+{% api-method-body-parameters %}
+{% api-method-parameter name="body" type="object" required=true %}
+{
+  "order": {
+    "purchaseOrderNumber": "PO123456789",
+    "indicators": {
+      "completed": true
+    }
+  },
+  "lines": [
+    {
+      "position": "0001",
+      "indicators": {
+        "completed": true
+      }
+    }
+  ]
+}
+{% endapi-method-parameter %}
+{% endapi-method-body-parameters %}
+{% endapi-method-request %}
+
+{% api-method-response %}
+{% api-method-response-example httpCode=200 %}
+{% endapi-method-response %}
+{% endapi-method-spec %}
+{% endapi-method %}
+
+{% hint style="info" %}
+[Send order OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)
+{% endhint %}
 
 {% hint style="warning" %}
 You cannot complete a `Cancelled` line
@@ -21,6 +88,3 @@ You cannot complete a `Cancelled` line
 {% hint style="info" %}
 Order lines having process status `Issued`, `In Progress` or `Confirmed` will become `Completed`
 {% endhint %}
-
-
-

--- a/buyer/complete.md
+++ b/buyer/complete.md
@@ -12,9 +12,9 @@ Complete an order line in Tradecloud when it is completely handled at the buyer,
 - Completing has precedence over cancelling at the same time
 
 
-## Completing by resending an order
+## Completing by resending an order using the `/order` API
 
-The order or line can be marked as completed by setting `indicators.completed` on either order or line level and updating the order.
+The order or line can be marked as completed by setting `indicators.completed` on either order or line level and updating the order using the `/order` API resource.
 
 {% hint style="info" %}
 If you provide a `completed` indicator on order level, **ONLY** the lines provided in this order message will be completed.
@@ -24,9 +24,9 @@ If you also provide a `completed` indicator on line level, it has **precedence**
 
 {% page-ref page="update.md" %}
 
-## Completing by sending the complete indicator
+## Completing by sending the completed indicator using the `/order/indicators` API
 
-The order or line can be marked as completed by setting `indicators.completed` on either order or line level and sending this indicator only.
+The order or line can be marked as completed by setting `indicators.completed` on either order or line level and sending this indicator only, using the `/order/indicators` API resource.
 
 {% hint style="info" %}
 If you provide a `completed` indicator on order level, **ALL** the lines in the order will be completed.

--- a/buyer/complete.md
+++ b/buyer/complete.md
@@ -4,11 +4,11 @@ description: How to complete an order or line
 
 # Complete an order
 
-{% hint style="warning" %}
-This feature is planned.
-{% endhint %}
+Complete an order line when it is completely handled at the buyer, usually when the supplier invoice is received and approved by buyer.
 
-When an order or line is completely handled at the buyer, usually when the supplier invoice is received and approved by buyer.
+- `Issued`, `Rejected` and `Confirmed` lines will become `Completed`
+- `In progress` and `Cancelled` lines cannot be completed
+- `Completed` lines cannot be completed again
 
 ## Completing by resending an order
 
@@ -78,13 +78,5 @@ application/json
 {% endapi-method %}
 
 {% hint style="info" %}
-[Send order OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)
-{% endhint %}
-
-{% hint style="warning" %}
-You cannot complete a `Cancelled` line
-{% endhint %}
-
-{% hint style="info" %}
-Order lines having process status `Issued`, `In Progress` or `Confirmed` will become `Completed`
+[Send order indicators OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)
 {% endhint %}

--- a/buyer/complete.md
+++ b/buyer/complete.md
@@ -34,7 +34,7 @@ If you also provide a `completed` indicator on line level, it has **precedence**
 
 {% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}
 {% api-method-summary %}
-Send order by buyer
+Send order indicators by buyer
 {% endapi-method-summary %}
 
 {% api-method-description %}

--- a/buyer/complete.md
+++ b/buyer/complete.md
@@ -12,20 +12,22 @@ Complete an order line when it is completely handled at the buyer, usually when 
 
 ## Completing by resending an order
 
-The order or line can be marked as completed by setting `indicators.completed`on either order or line level and updating the order.
+The order or line can be marked as completed by setting `indicators.completed` on either order or line level and updating the order.
 
 {% hint style="info" %}
 If you provide a completed indicator on order level, ONLY the lines provided in this order message will be completed.
+If you also provide a completed indicator on line level, it has precedence over the order level completed indicator.
 {% endhint %}
 
 {% page-ref page="update.md" %}
 
 ## Completing by sending the complete indicator
 
-The order or can be marked as competed  by setting `indicators.completed`on either order or line level and sending the indicator only.
+The order or can be marked as completed by setting `indicators.completed` on either order or line level and sending the indicator only.
 
 {% hint style="info" %}
-If you provide a completed indicator on order level, ALL the lines in the order will be completed, regardless the lines provided in this order indicators message.
+If you provide a completed indicator on order level, ALL the lines in the order will be completed.
+If you also provide a completed indicator on line level, it has precedence over the order level completed indicator.
 {% endhint %}
 
 {% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}
@@ -51,6 +53,7 @@ application/json
 
 {% api-method-body-parameters %}
 {% api-method-parameter name="body" type="object" required=true %}
+```
 {
   "order": {
     "purchaseOrderNumber": "PO123456789",
@@ -67,6 +70,7 @@ application/json
     }
   ]
 }
+```
 {% endapi-method-parameter %}
 {% endapi-method-body-parameters %}
 {% endapi-method-request %}

--- a/buyer/complete.md
+++ b/buyer/complete.md
@@ -53,6 +53,17 @@ application/json
 
 {% api-method-body-parameters %}
 {% api-method-parameter name="body" type="object" required=true %}
+{% endapi-method-parameter %}
+{% endapi-method-body-parameters %}
+{% endapi-method-request %}
+
+{% api-method-response %}
+{% api-method-response-example httpCode=200 %}
+{% endapi-method-response %}
+{% endapi-method-spec %}
+{% endapi-method %}
+
+Body example:
 ```
 {
   "order": {
@@ -71,15 +82,7 @@ application/json
   ]
 }
 ```
-{% endapi-method-parameter %}
-{% endapi-method-body-parameters %}
-{% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
-{% endapi-method %}
 
 {% hint style="info" %}
 [Send order indicators OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)

--- a/buyer/complete.md
+++ b/buyer/complete.md
@@ -9,6 +9,8 @@ Complete an order line in Tradecloud when it is completely handled at the buyer,
 - `Issued`, `Rejected` and `Confirmed` lines will become `Completed`
 - `In progress` and `Cancelled` lines cannot be completed
 - `Completed` lines cannot be completed again
+- Completing has precedence over cancelling at the same time
+
 
 ## Completing by resending an order
 

--- a/buyer/indicators.md
+++ b/buyer/indicators.md
@@ -6,18 +6,16 @@ description: How to use order and line indicators as a buyer
 
 ## Indicators
 
-When sending a purchase order to Tradecloud you can optionally set indicators on both order and line levels.
-
-{% hint style="info" %}
+You can set indicators on both order and line levels.
 Line indicators have precedence over \(overrule\) order indicators.
-{% endhint %}
 
 ### No delivery expected
 
 `noDeliveryExpected`: no goods of are expected to be delivered to the buyer.
 
 {% hint style="warning" %}
-This feature is planned. Ticket [TC-5564](https://tradecloud.atlassian.net/browse/TC-5564) As a buyer I want to set a "No delivery expected" indicator
+This feature is planned. Ticket [TC-5564](https://tradecloud.atlassian.net/browse/TC-5564)
+ As a buyer I want to set a "No delivery expected" indicator
 {% endhint %}
 
 {% hint style="info" %}
@@ -26,27 +24,21 @@ Order lines having `noDeliveryExpected` set will NEVER become `overdue`
 
 ### Shipped by supplier
 
-`shipped`: all goods of the order or line are completely shipped by the supplier. 
+`shipped`: all goods of the order or line are completely shipped by the supplier.
 
 {% hint style="warning" %}
 This feature is planned. Ticket [TC-5667](https://tradecloud.atlassian.net/browse/TC-5667) As buyer I want to see order lines receive the logistical status ''Shipped'' when they have the status "shipped" in my ERP system.
 {% endhint %}
 
+- Order lines having logistics status `Open` will become `Shipped`
+- `Delivered` lines cannot be shipped
+- `Shipped` lines cannot be shipped again
+
 {% hint style="warning" %}
 Usually this is indicator is set in the `order-response` by the supplier but in some cases a buyer requires to set it.
 {% endhint %}
 
-{% hint style="info" %}
-Order lines having logistics status `Open` will become `Shipped`
-
-You cannot ship a delivered line.
-{% endhint %}
-
 ### Delivered at buyer
-
-{% hint style="warning" %}
-This feature is planned. [TC-5121 ](https://tradecloud.atlassian.net/browse/TC-5121)As buyer I want to see order lines receive the logistical status ''Shipped/Delivered'' when they have the status "shipped/Delivered" in my ERP system.
-{% endhint %}
 
 `delivered`: all goods of the order or line are completely delivered at the buyer.
 
@@ -56,61 +48,23 @@ Order lines having logistics status `Open` or `Shipped` will become `Delivered`
 
 ### Completed at buyer
 
-{% hint style="warning" %}
-This feature is planned.  Ticket [TC-5186](https://tradecloud.atlassian.net/browse/TC-5186) As a buyer I want to complete orders and lines
-{% endhint %}
-
 `completed`: the order or line is completed at the buyer. Usually this indicator is set when the invoice is received and approved by buyer.
 
-{% hint style="warning" %}
-You cannot complete a `Cancelled` line
-{% endhint %}
-
-{% hint style="info" %}
-Order lines having process status `Issued`, `In Progress` or `Confirmed` will become `Completed`
-{% endhint %}
-
-### Reopened at buyer
-
-{% hint style="warning" %}
-This feature is planned. Ticket TC-4480 As a buyer I want to reopen an order line using a reopen request workflow
-{% endhint %}
-
-`reopened`: the order or line is reopened at the buyer
-
-{% hint style="warning" %}
-This is a **request** to the supplier to reopen an already agreed order or line. 
-
-The supplier has to approve the reopen request.
-{% endhint %}
-
-{% hint style="warning" %}
-You cannot reopen a `Completed` or `Cancelled` order or line
-{% endhint %}
-
-{% hint style="info" %}
-Order lines having process status `Confirmed` will become `InProgress`
-{% endhint %}
+- `Issued`, `Rejected` and `Confirmed` lines will become `Completed`
+- `In progress` and `Cancelled` lines cannot be completed
+- `Completed` lines cannot be completed again
+- Completing has precedence over cancelling at the same time
 
 ### Cancelled at buyer
-
-{% hint style="warning" %}
-This feature is planned. Ticket [TC-4479](https://tradecloud.atlassian.net/browse/TC-4479) As a buyer I want to cancel an order line using a cancel request workflow.
-{% endhint %}
 
 `cancelled`: the order or line is cancelled at the buyer
 
 {% hint style="warning" %}
-This is a **request** to the supplier to cancel an order or line. 
+This is a **request** to the supplier to cancel an order or line.
 
 The supplier has to approve the cancel request.
 {% endhint %}
 
-{% hint style="warning" %}
-You cannot cancel a `Completed` line
-{% endhint %}
-
-{% hint style="info" %}
-Order lines having process status `Issued`, `In Progress` or `Confirmed` will become `Cancelled`
-{% endhint %}
-
+- `Issued`, `In Progress`, `Rejected` and `Confirmed` lines will become `Cancelled` immediately (without request)
+- `Completed` lines cannot be cancelled
+- `Cancelled` lines cannot be cancelled again

--- a/buyer/receive-goods.md
+++ b/buyer/receive-goods.md
@@ -6,11 +6,13 @@ description: How to announce the buyer has received goods
 
 There are two ways to announce the buyer has received goods. Using the actual delivery schedule is preferred over the delivered indicator, as it is more precise regarding partial deliveries.
 
-## Actual delivery schedule
+## Actual delivery history
 
-This schedule contains the actual physical deliveries. With the actual deliveries versus the planned deliveries Tradecloud can calculate which goods should still be delivered or are overdue.
+The delivery history schedule contains the actual physical deliveries. With the actual deliveries versus the planned deliveries Tradecloud can calculate which goods should still be delivered or are overdue.
 
-The actual delivery schedule can be send by setting the `lines.deliveryHistory` and updating the order:
+### Send the delivery history by resending an order using the `/order` API
+
+The actual delivery schedule can be send by setting the `lines.deliveryHistory` and updating the order using the `/order` API resource:
 
 {% page-ref page="update.md" %}
 
@@ -18,9 +20,9 @@ The actual delivery schedule can be send by setting the `lines.deliveryHistory` 
 
 When an order or line is received, regardless of actual quantity or date, it can can be marked as delivered by setting `indicators.delivered` on either order or line level.
 
-### Mark as delivered by resending an order
+### Mark as delivered by resending an order using the `/order` API
 
-The order or line can be marked as delivered by setting `indicators.delivered` on either order or line level and updating the order.
+The order or line can be marked as delivered by setting `indicators.delivered` on either order or line level and updating the order using the `/order` API resource.
 
 {% hint style="info" %}
 If you provide a `delivered` indicator on order level, **ONLY** the lines provided in this order message will be marked as delivered.
@@ -30,9 +32,9 @@ If you also provide a `delivered` indicator on line level, it has **precedence**
 
 {% page-ref page="update.md" %}
 
-### Mark as delivered by sending the delivered indicator
+### Mark as delivered by sending the delivered indicator using the `/order/indicators` API
 
-The order or line can be marked as delivered by setting `indicators.delivered` on either order or line level and sending this indicator only.
+The order or line can be marked as delivered by setting `indicators.delivered` on either order or line level and sending this indicator only, using the `/order/indicators` API resource.
 
 {% hint style="info" %}
 If you provide a `delivered` indicator on order level, **ALL** the lines in the order will be delivered.

--- a/buyer/receive-goods.md
+++ b/buyer/receive-goods.md
@@ -8,21 +8,91 @@ There are two ways to announce the buyer has received goods. Using the actual de
 
 ## Actual delivery schedule
 
-This schedule contains the actual physical deliveries. With the actual deliveries versus the planned deliveries Tradecloud can calculate which goods should still be delivered or are even overdue.
+This schedule contains the actual physical deliveries. With the actual deliveries versus the planned deliveries Tradecloud can calculate which goods should still be delivered or are overdue.
 
-The actual delivery schedule can be send by setting `lines.deliveryHistory` and update the order:
+The actual delivery schedule can be send by setting the `lines.deliveryHistory` and updating the order:
 
 {% page-ref page="update.md" %}
 
 ## Delivered indicator
 
-{% hint style="warning" %}
-This feature is planned and API and documentation may change. 
-{% endhint %}
+When an order or line is received, regardless of actual quantity or date, it can can be marked as delivered by setting `indicators.delivered` on either order or line level.
 
-When an order or line is received, regardless of actual quantity or date, it can can be marked as delivered by setting `indicators.delivered`on either order or line level and update the order:
+## Mark as delivered by resending an order
+
+The order or line can be marked as delivered by setting `indicators.delivered` on either order or line level and updating the order.
+
+{% hint style="info" %}
+If you provide a `delivered` indicator on order level, **ONLY** the lines provided in this order message will be marked as delivered.
+
+If you also provide a `delivered` indicator on line level, it has **precedence** over the order level `delivered` indicator.
+{% endhint %}
 
 {% page-ref page="update.md" %}
 
+## Mark as delivered by sending the delivered indicator
 
+The order or line can be marked as delivered by setting `indicators.delivered` on either order or line level and sending this indicator only.
 
+{% hint style="info" %}
+If you provide a `delivered` indicator on order level, **ALL** the lines in the order will be delivered.
+
+If you also provide a `delivered` indicator on line level, it has **precedence** over the order level `delivered` indicator.
+{% endhint %}
+
+{% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}
+{% api-method-summary %}
+Send order indicators by buyer
+{% endapi-method-summary %}
+
+{% api-method-description %}
+
+{% endapi-method-description %}
+
+{% api-method-spec %}
+{% api-method-request %}
+{% api-method-headers %}
+{% api-method-parameter name="Authorization" type="string" required=true %}
+Bearer Access-Token
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="Content-Type" type="string" required=true %}
+application/json
+{% endapi-method-parameter %}
+{% endapi-method-headers %}
+
+{% api-method-body-parameters %}
+{% api-method-parameter name="body" type="object" required=true %}
+{% endapi-method-parameter %}
+{% endapi-method-body-parameters %}
+{% endapi-method-request %}
+
+{% api-method-response %}
+{% api-method-response-example httpCode=200 %}
+{% endapi-method-response %}
+{% endapi-method-spec %}
+{% endapi-method %}
+
+Body example:
+```
+{
+  "order": {
+    "purchaseOrderNumber": "PO123456789",
+    "indicators": {
+      "delivered": true
+    }
+  },
+  "lines": [
+    {
+      "position": "0001",
+      "indicators": {
+        "delivered": true
+      }
+    }
+  ]
+}
+```
+
+{% hint style="info" %}
+[Send order indicators OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)
+{% endhint %}

--- a/buyer/receive-goods.md
+++ b/buyer/receive-goods.md
@@ -18,7 +18,7 @@ The actual delivery schedule can be send by setting the `lines.deliveryHistory` 
 
 When an order or line is received, regardless of actual quantity or date, it can can be marked as delivered by setting `indicators.delivered` on either order or line level.
 
-## Mark as delivered by resending an order
+### Mark as delivered by resending an order
 
 The order or line can be marked as delivered by setting `indicators.delivered` on either order or line level and updating the order.
 
@@ -30,7 +30,7 @@ If you also provide a `delivered` indicator on line level, it has **precedence**
 
 {% page-ref page="update.md" %}
 
-## Mark as delivered by sending the delivered indicator
+### Mark as delivered by sending the delivered indicator
 
 The order or line can be marked as delivered by setting `indicators.delivered` on either order or line level and sending this indicator only.
 

--- a/buyer/ship-goods.md
+++ b/buyer/ship-goods.md
@@ -23,14 +23,14 @@ Usually this is indicator is set in the `order-response` by the supplier but in 
 The order or line can be marked as shipped by setting `indicators.shipped` on either order or line level and updating the order.
 
 {% hint style="info" %}
-If you provide a `shipped` indicator on order level, **ONLY** the lines provided in this order message will be completed.
+If you provide a `shipped` indicator on order level, **ONLY** the lines provided in this order message will be shipped.
 
 If you also provide a `shipped` indicator on line level, it has **precedence** over the order level `shipped` indicator.
 {% endhint %}
 
 {% page-ref page="update.md" %}
 
-##  Mark as shipped by sending the complete indicator
+## Mark as shipped by sending the shipped indicator
 
 The order or line can be marked as completed by setting `indicators.shipped` on either order or line level and sending this indicator only.
 

--- a/buyer/ship-goods.md
+++ b/buyer/ship-goods.md
@@ -8,19 +8,91 @@ description: How to announce the supplier has shipped goods
 This feature is planned and API and documentation may change. 
 {% endhint %}
 
-When an order or line is completely shipped by the supplier, it can be marked as shipped by setting `indicators.shipped`on either order or line level and update the order:
+When an order or line is completely shipped by the supplier, it can be marked as shipped by setting `indicators.shipped` on either order or line level.
 
-{% page-ref page="update.md" %}
-
-{% hint style="info" %}
-Order lines having logistics status `Open` will become `Shipped`
-
-You cannot ship a `Delivered` line.
-{% endhint %}
+- Order lines having logistics status `Open` will become `Shipped`
+- `Delivered` lines cannot be shipped
+- `Shipped` lines cannot be shipped again
 
 {% hint style="warning" %}
 Usually this is indicator is set in the `order-response` by the supplier but in some cases a buyer requires to set it.
 {% endhint %}
 
+## Mark as shipped by resending an order
 
+The order or line can be marked as shipped by setting `indicators.shipped` on either order or line level and updating the order.
 
+{% hint style="info" %}
+If you provide a `shipped` indicator on order level, **ONLY** the lines provided in this order message will be completed.
+
+If you also provide a `shipped` indicator on line level, it has **precedence** over the order level `shipped` indicator.
+{% endhint %}
+
+{% page-ref page="update.md" %}
+
+##  Mark as shipped by sending the complete indicator
+
+The order or line can be marked as completed by setting `indicators.shipped` on either order or line level and sending this indicator only.
+
+{% hint style="info" %}
+If you provide a `shipped` indicator on order level, **ALL** the lines in the order will be shipped.
+
+If you also provide a `shipped` indicator on line level, it has **precedence** over the order level `shipped` indicator.
+{% endhint %}
+
+{% api-method method="post" host="https://api.accp.tradecloud1.com/v2" path="/api-connector/order/indicators" %}
+{% api-method-summary %}
+Send order indicators by buyer
+{% endapi-method-summary %}
+
+{% api-method-description %}
+
+{% endapi-method-description %}
+
+{% api-method-spec %}
+{% api-method-request %}
+{% api-method-headers %}
+{% api-method-parameter name="Authorization" type="string" required=true %}
+Bearer Access-Token
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="Content-Type" type="string" required=true %}
+application/json
+{% endapi-method-parameter %}
+{% endapi-method-headers %}
+
+{% api-method-body-parameters %}
+{% api-method-parameter name="body" type="object" required=true %}
+{% endapi-method-parameter %}
+{% endapi-method-body-parameters %}
+{% endapi-method-request %}
+
+{% api-method-response %}
+{% api-method-response-example httpCode=200 %}
+{% endapi-method-response %}
+{% endapi-method-spec %}
+{% endapi-method %}
+
+Body example:
+```
+{
+  "order": {
+    "purchaseOrderNumber": "PO123456789",
+    "indicators": {
+      "shipped": true
+    }
+  },
+  "lines": [
+    {
+      "position": "0001",
+      "indicators": {
+        "shipped": true
+      }
+    }
+  ]
+}
+```
+
+{% hint style="info" %}
+[Send order indicators OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)
+{% endhint %}

--- a/buyer/ship-goods.md
+++ b/buyer/ship-goods.md
@@ -18,9 +18,9 @@ When an order or line is completely shipped by the supplier, it can be marked as
 Usually this is indicator is set in the `order-response` by the supplier but in some cases a buyer requires to set it.
 {% endhint %}
 
-## Mark as shipped by resending an order
+## Mark as shipped by resending an order using the `/order` API
 
-The order or line can be marked as shipped by setting `indicators.shipped` on either order or line level and updating the order.
+The order or line can be marked as shipped by setting `indicators.shipped` on either order or line level and updating the order using the `/order` API resource.
 
 {% hint style="info" %}
 If you provide a `shipped` indicator on order level, **ONLY** the lines provided in this order message will be shipped.
@@ -30,9 +30,9 @@ If you also provide a `shipped` indicator on line level, it has **precedence** o
 
 {% page-ref page="update.md" %}
 
-## Mark as shipped by sending the shipped indicator
+## Mark as shipped by sending the shipped indicator using the `/order/indicators` API
 
-The order or line can be marked as completed by setting `indicators.shipped` on either order or line level and sending this indicator only.
+The order or line can be marked as completed by setting `indicators.shipped` on either order or line level and sending this indicator only, using the `/order/indicators` API resource.
 
 {% hint style="info" %}
 If you provide a `shipped` indicator on order level, **ALL** the lines in the order will be shipped.


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-6430

### Scope
This PR adds the orders indicators API resource to the API manual

https://tradecloud.gitbook.io/api/~/revisions/-MO67_Ge1Vm7StlRI34L/v/TC-6630-add-order-indicators/

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
