### PR TITLE
[TC-6710] Send only new or changed lines

### DIFF
--- a/api/rules.md
+++ b/api/rules.md
@@ -54,11 +54,16 @@ Do **not** send more than **10 requests per second**.
 
 Tradecloud may respond with [HTTP Status Code 429](https://tools.ietf.org/html/rfc6585#section-4) `Too Many Requests`
 
-### Only resend changed orders or order responses
+### Only send new or changed orders or order responses
 
-Only resend an order or order response that **has an actual change**
+Only send an **order** or **order response** that either **is new** or **has an actual change**
 
-### **Never send all orders or responses periodically**
+### The order or order response should only contain new or changed lines
+
+The order or order response should only contain **order lines** that are **new or changed**.
+Sending an unchanged order line could trigger an unexpected line status change in Tradecloud.
+
+### Never send all orders or responses periodically
 
 Never resend **all** or **all active** orders or responses periodically.
 

--- a/buyer/issue/README.md
+++ b/buyer/issue/README.md
@@ -4,7 +4,12 @@ description: How to issue a new purchase order as a buyer
 
 # Issue a new order
 
-As buyer you can send either a new or [updated](../update.md) purchase order to your supplier.
+As buyer you can send either a **new or [updated](../update.md)** purchase order to your supplier.
+
+{% hint style="warning" %}
+The order should only contain **order lines** that are **new or changed**.
+Sending an unchanged order line could trigger an unexpected line status change in Tradecloud.
+{% endhint %}
 
 ## Order process
 
@@ -68,7 +73,7 @@ Order JSON body
 The `supplierAccountNumber` should be set on forehand in the Tradecloud connection with your supplier. You can set the account code when inviting a new connection or in the connection overview in the portal.
 {% endhint %}
 
-#### Other order fields
+### Other order fields
 
 * `description`: a free format additional description of this order
 * `terms`: the order terms as agreed with your supplier

--- a/buyer/update.md
+++ b/buyer/update.md
@@ -6,6 +6,11 @@ description: How to update an existing purchase order as a buyer
 
 As buyer you can send either a [new](issue/) or updated purchase order to Tradecloud.
 
+{% hint style="warning" %}
+The order should only contain **order lines** that are **new or changed**.
+Sending an unchanged order line could trigger an unexpected line status change in Tradecloud.
+{% endhint %}
+
 ## Order process
 
 After sending an updated order to Tradecloud the order line **process status may change**:

--- a/supplier/send-order-response/README.md
+++ b/supplier/send-order-response/README.md
@@ -4,7 +4,12 @@ description: How to send a purchase order response to your buyer.
 
 # Send order response
 
-As a supplier you can send either a new or updated purchase order response to your buyer.
+As a supplier you can send either a **new or updated** purchase order response to your buyer.
+
+{% hint style="warning" %}
+The order response should only contain **order lines** that are **new or changed**.
+Sending an unchanged order line could trigger an unexpected line status change in Tradecloud.
+{% endhint %}
 
 ## Order process
 


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-6710

### Scope
This PR adds a rule and warnings to only send new or changes lines in an order or order response

https://tradecloud.gitbook.io/api/~/revisions/-MSKEhpRW36ToItjcyL5/v/TC-6710-send-only-new-or-changed-lines/api/rules#the-order-or-order-response-should-only-contain-new-or-changed-lines

https://tradecloud.gitbook.io/api/~/revisions/-MSKEhpRW36ToItjcyL5/v/TC-6710-send-only-new-or-changed-lines/buyer/issue

https://tradecloud.gitbook.io/api/~/revisions/-MSKEhpRW36ToItjcyL5/v/TC-6710-send-only-new-or-changed-lines/supplier/send-order-response

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
