### PR TITLE
[TC-6957] [TC-7119] Add `cancelLineWhenMissing` indicator

### DIFF
--- a/buyer/cancel.md
+++ b/buyer/cancel.md
@@ -24,7 +24,7 @@ If you also provide a `cancelled` indicator on line level, it has **precedence**
 
 ## Cancelling by resending the order without the cancelled line using the `/order` API
 
-Cancel an order line by setting the `indicators.cancelLineWhenMissing` on order level, and updating the order WITHOUT the cancelled line, using the `/order` API resource.
+You can cancel an order line by using the `/order` API resource, by setting the `indicators.cancelLineWhenMissing` on order level and updating the order WITHOUT including the cancelled line.
 
 This is useful when your ERP system cannot cancel a line, but instead removes a line from the order.
 

--- a/buyer/cancel.md
+++ b/buyer/cancel.md
@@ -12,7 +12,7 @@ Cancel an order line in Tradecloud when it is cancelled at the buyer.
 
 ## Cancelling by resending an order using the `/order` API
 
-The order or line can be cancelled by setting `indicators.cancelled` on either order or line level and updating the order using the `/order` API resource.
+You can cancel the order or line by setting `indicators.cancelled` on either order or line level and updating the order using the `/order` API resource.
 
 {% hint style="info" %}
 If you provide a `cancelled` indicator on order level, **ONLY** the lines provided in this order message will be cancelled.
@@ -26,13 +26,15 @@ If you also provide a `cancelled` indicator on line level, it has **precedence**
 
 You can cancel an order line by using the `/order` API resource, by setting the `indicators.cancelLineWhenMissing` on order level and updating the order WITHOUT including the cancelled line.
 
+You can cancel a full order (all the lines) by setting the `indicators.cancelLineWhenMissing` on order level and updating the order WITHOUT any lines.
+
 This is useful when your ERP system cannot cancel a line, but instead removes a line from the order.
 
 {% page-ref page="update.md" %}
 
 ## Cancelling by sending the cancelled indicator using the `/order/indicators` API
 
-The order or can be cancelled by setting `indicators.cancelled` on either order or line level and sending this indicator only, using the `/order/indicators` API resource.
+You can cancel the order or line by setting `indicators.cancelled` on either order or line level and sending this indicator only, using the `/order/indicators` API resource.
 
 {% hint style="info" %}
 If you provide a `cancelled` indicator on order level, **ALL** the lines in the order will be cancelled.

--- a/buyer/cancel.md
+++ b/buyer/cancel.md
@@ -22,6 +22,14 @@ If you also provide a `cancelled` indicator on line level, it has **precedence**
 
 {% page-ref page="update.md" %}
 
+## Cancelling by resending the order without the cancelled line using the `/order` API
+
+Cancel an order line by setting the `indicators.cancelLineWhenMissing` on order level, and updating the order WITHOUT the cancelled line, using the `/order` API resource.
+
+This is useful when your ERP system cannot cancel a line, but instead removes a line from the order.
+
+{% page-ref page="update.md" %}
+
 ## Cancelling by sending the cancelled indicator using the `/order/indicators` API
 
 The order or can be cancelled by setting `indicators.cancelled` on either order or line level and sending this indicator only, using the `/order/indicators` API resource.
@@ -90,4 +98,3 @@ Body example:
 {% hint style="info" %}
 [Send order indicators OpenAPI Specification](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderIndicatorsByBuyerRoute)
 {% endhint %}
-

--- a/buyer/indicators.md
+++ b/buyer/indicators.md
@@ -15,10 +15,10 @@ Line indicators have precedence over \(overrule\) order indicators.
 
 {% hint style="warning" %}
 This feature is planned. Ticket [TC-5564](https://tradecloud.atlassian.net/browse/TC-5564)
- As a buyer I want to set a "No delivery expected" indicator
+ As a buyer I want to set a "No delivery expected" indicator.
 {% endhint %}
 
-{% hint style="info" %}
+{% hint style="info" %}.
 Order lines having `noDeliveryExpected` set will NEVER become `overdue`
 {% endhint %}
 
@@ -31,7 +31,7 @@ Order lines having `noDeliveryExpected` set will NEVER become `overdue`
 `delivered`: all goods of the order or line are completely delivered at the buyer.
 
 {% hint style="info" %}
-Order lines having logistics status `Open`, `Produced`, `ReadyToShip` or `Shipped` will become `Delivered`
+Order lines having logistics status `Open`, `Produced`, `ReadyToShip` or `Shipped` will become `Delivered`.
 {% endhint %}
 
 ### Completed at buyer
@@ -45,13 +45,15 @@ Order lines having logistics status `Open`, `Produced`, `ReadyToShip` or `Shippe
 
 ### Cancelled at buyer
 
-`cancelled`: the order or line is cancelled at the buyer
+`cancelled`: the order or line is cancelled at the buyer.
 
-{% hint style="warning" %}
-This is a **request** to the supplier to cancel an order or line.
+- `Issued`, `In Progress`, `Rejected` and `Confirmed` lines will become `Cancelled` immediately.
+- `Completed` lines cannot be cancelled
+- `Cancelled` lines cannot be cancelled again
 
-The supplier has to approve the cancel request.
-{% endhint %}
+### Cancel line when missing
+
+`cancelLineWhenMissing`: when set on order level, and a line is missing in the order update, the line is assumed cancelled at the buyer.
 
 - `Issued`, `In Progress`, `Rejected` and `Confirmed` lines will become `Cancelled` immediately (without request)
 - `Completed` lines cannot be cancelled

--- a/buyer/indicators.md
+++ b/buyer/indicators.md
@@ -18,8 +18,8 @@ This feature is planned. Ticket [TC-5564](https://tradecloud.atlassian.net/brows
  As a buyer I want to set a "No delivery expected" indicator.
 {% endhint %}
 
-{% hint style="info" %}.
-Order lines having `noDeliveryExpected` set will NEVER become `overdue`
+{% hint style="info" %}
+Order lines having `noDeliveryExpected` set will NEVER become `overdue`.
 {% endhint %}
 
 ### Shipped by supplier
@@ -38,23 +38,23 @@ Order lines having logistics status `Open`, `Produced`, `ReadyToShip` or `Shippe
 
 `completed`: the order or line is completed at the buyer. Usually this indicator is set when the invoice is received and approved by buyer.
 
-- `Issued`, `Rejected` and `Confirmed` lines will become `Completed`
-- `In progress` and `Cancelled` lines cannot be completed
-- `Completed` lines cannot be completed again
-- Completing has precedence over cancelling at the same time
+- `Issued`, `Rejected` and `Confirmed` lines will become `Completed`.
+- `In progress` and `Cancelled` lines cannot be completed.
+- `Completed` lines cannot be completed again.
+- Completing has precedence over cancelling at the same time.
 
 ### Cancelled at buyer
 
 `cancelled`: the order or line is cancelled at the buyer.
 
 - `Issued`, `In Progress`, `Rejected` and `Confirmed` lines will become `Cancelled` immediately.
-- `Completed` lines cannot be cancelled
-- `Cancelled` lines cannot be cancelled again
+- `Completed` lines cannot be cancelled.
+- `Cancelled` lines cannot be cancelled again.
 
 ### Cancel line when missing
 
 `cancelLineWhenMissing`: when set on order level, and a line is missing in the order update, the line is assumed cancelled at the buyer.
 
-- `Issued`, `In Progress`, `Rejected` and `Confirmed` lines will become `Cancelled` immediately (without request)
-- `Completed` lines cannot be cancelled
-- `Cancelled` lines cannot be cancelled again
+- `Issued`, `In Progress`, `Rejected` and `Confirmed` lines will become `Cancelled` immediately.
+- `Completed` lines cannot be cancelled.
+- `Cancelled` lines cannot be cancelled again.

--- a/buyer/update.md
+++ b/buyer/update.md
@@ -109,6 +109,8 @@ Additional indicators may be set in an order update:
 
 {% page-ref page="complete.md" %}
 
+{% page-ref page="cancel.md" %}
+
 {% page-ref page="reopen.md" %}
 
 ## Updated order meta data


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
Story: https://tradecloud.atlassian.net/browse/TC-6957
Sub task: https://tradecloud.atlassian.net/browse/TC-7119

### Scope
This PR adds `cancelLineWhenMissing` indicator to the API manual.
https://app.gitbook.com/@tradecloud/s/api/v/TC-7119-cancelLineWhenMissing-indicator/buyer/cancel#cancelling-by-resending-the-order-without-the-cancelled-line-using-the-order-api

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
