### PR TITLE
[TC-7158] Add propose when accepted

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -39,6 +39,7 @@
     * [Attach a document to an order](buyer/issue/attach-document.md)
     * [Choose attach document API](buyer/issue/attach-document-api.md)
     * [No delivery expected](buyer/issue/no-delivery-expected.md)
+    * [Propose when accepted](buyer/issue/propose-when-accepted.md)
   * [Update an existing order](buyer/update.md)
   * [Receive an order response](buyer/receive/README.md)
     * [Download a document attached to an order response](buyer/receive/download-document.md)

--- a/buyer/issue/README.md
+++ b/buyer/issue/README.md
@@ -142,7 +142,6 @@ The webhook `orderEvent.lines.itemDetails.mergedItemDetails` will contain the me
 * `deliverySchedule.position`: the optional position in the delivery schedule. Required when using `status`. Not to be confused with the `line.position`
 * `deliverySchedule.date`: the requested delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
 * `deliverySchedule.quantity`: the requested quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
-* `deliverySchedule.quantity`: the requested quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
 * `deliverySchedule.status`: The logistics status of this delivery line according to the buyer. The `deliverySchedule.position` MUST be set when providing `status`.
 
 {% hint style="warning" %}

--- a/buyer/issue/README.md
+++ b/buyer/issue/README.md
@@ -81,7 +81,9 @@ The `supplierAccountNumber` should be set on forehand in the Tradecloud connecti
 
 * `description`: a free format additional description of this order
 * `terms`: the order terms as agreed with your supplier
-* `indicators`: 
+* `indicators`:
+
+When all order lines have no goods to be delivered, for example service, fee or text lines:
 
 {% page-ref page="no-delivery-expected.md" %}
 
@@ -140,9 +142,22 @@ The webhook `orderEvent.lines.itemDetails.mergedItemDetails` will contain the me
 * `deliverySchedule.position`: the optional position in the delivery schedule. Required when using `status`. Not to be confused with the `line.position`
 * `deliverySchedule.date`: the requested delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
 * `deliverySchedule.quantity`: the requested quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
+* `deliverySchedule.quantity`: the requested quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
+* `deliverySchedule.status`: The logistics status of this delivery line according to the buyer. The `deliverySchedule.position` MUST be set when providing `status`.
 
 {% hint style="warning" %}
 `deliverySchedule.position` should be unique within the delivery schedule and never change. Never renumber or re-use `deliverySchedule.position`s.
+{% endhint %}
+
+{% hint style="info" %}
+The delivery line logistics status is one of:
+
+* `ReadyToShip`: full quantity ready to be shipped by the supplier
+
+These logistics statuses are under development and API and documentation may change:
+
+* `Shipped`: full quantity shipped by the supplier
+* `Delivered`: full quantity delivered at the buyer
 {% endhint %}
 
 ### Requested prices
@@ -155,7 +170,7 @@ The webhook `orderEvent.lines.itemDetails.mergedItemDetails` will contain the me
 * `priceUnitOfMeasureIso`: the price unit according to ISO 80000-1. The purchase unit and price unit may be different.
 * `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
 
-#### Other line fields
+### Other line fields
 
 * `description`: a free format additional description of this line
 * `terms`: the line terms as agreed with your supplier
@@ -166,7 +181,13 @@ The webhook `orderEvent.lines.itemDetails.mergedItemDetails` will contain the me
 * `salesOrderNumber`:  Your sales order reference \(not be confused with the supplier sales order number\)
 * `indicators`:
 
+When a line has no goods to be delivered, for example a service, fee or text line:
+
 {% page-ref page="no-delivery-expected.md" %}
+
+When your order process requires the buyer to always approve every line:
+
+{% page-ref page="propose-when-accepted.md" %}
 
 * `properties`: are key-value based custom fields. You can use as many as needed, but too many will clutter the portal.  Use `\n` for a new line in the value.
 * `documents`: contain attached documents, see:

--- a/buyer/issue/no-delivery-expected.md
+++ b/buyer/issue/no-delivery-expected.md
@@ -15,4 +15,3 @@ When a line has no goods to be delivered, for example a service, fee or text lin
 {% hint style="info" %}
 Lines having the `noDeliveryExpected` indicator set will never become`Overdue`
 {% endhint %}
-

--- a/buyer/issue/propose-when-accepted.md
+++ b/buyer/issue/propose-when-accepted.md
@@ -1,0 +1,9 @@
+---
+description: How to announce a line should always become a proposal when accepted by the supplier
+---
+
+# Propose when accepted
+
+Use `Propose when accepted` when your order process requires the buyer to always approve every order line, even when the supplier accepts (confirms with requested values) the order line. Every `Accepted by supplier` line becomes a proposal with requested values.
+
+You can set `Propose when accepted` by using the `/order` API resource, by setting the `indicators.proposeWhenAccepted` on line level.

--- a/buyer/update.md
+++ b/buyer/update.md
@@ -65,27 +65,6 @@ The update is event oriented, you only have to send the lines new or updated. Bu
 
 ## Additional fields
 
-### Logistics status in the planned delivery schedule
-
-The logistics status may be added to the requested delivery schedule in an order update:
-
-* `lines.deliverySchedule`: the requested delivery schedule. Provide all delivery schedule lines in an update.
-* `deliverySchedule.position`: the optional position in the delivery schedule. Required when using `status`. Not to be confused with the `line.position`
-* `deliverySchedule.date`: the requested delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-* `deliverySchedule.quantity`: the requested quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
-* `deliverySchedule.status`: The logistics status of this delivery line according to the buyer. The `deliverySchedule.position` MUST be set when providing `status`.
-
-{% hint style="info" %}
-The delivery line logistics status is one of:
-
-* `ReadyToShip`: full quantity ready to be shipped by the supplier
-
-These logistics statuses are under development and API and documentation may change:
-
-* `Shipped`: full quantity shipped by the supplier
-* `Delivered`: full quantity delivered at the buyer
-{% endhint %}
-
 ### Actual delivery history
 
 The actual delivery history may be added in an order update:


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
Story https://tradecloud.atlassian.net/browse/TC-6974
Sub task https://tradecloud.atlassian.net/browse/TC-7158

### Scope
This PR adds 
- the "Propose when accepted" feature to the API manual

https://tradecloud.gitbook.io/api/v/TC-7158-propose-when-accepted/buyer/issue#other-line-fields
https://tradecloud.gitbook.io/api/v/TC-7158-propose-when-accepted/buyer/issue/propose-when-accepted

- moves basic logistics from the `order update` to the `order issue` pages, as the delivery live status may be set already when issuing the order

https://tradecloud.gitbook.io/api/v/TC-7158-propose-when-accepted/buyer/issue#requested-planned-delivery-schedule

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
