### PR TITLE
[TC-7159] Improve delivery schedule position mandatory

### DIFF
--- a/buyer/issue/README.md
+++ b/buyer/issue/README.md
@@ -139,13 +139,15 @@ The webhook `orderEvent.lines.itemDetails.mergedItemDetails` will contain the me
 ### Requested planned delivery schedule
 
 * `line.deliverySchedule`: the requested planned delivery schedule. Provide at least one or multiple delivery schedule lines.
-* `deliverySchedule.position`: the optional position in the delivery schedule. Required when using `status`. Not to be confused with the `line.position`
+* `deliverySchedule.position`: the optional position in the delivery schedule. Not to be confused with the `line.position`.
 * `deliverySchedule.date`: the requested delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
 * `deliverySchedule.quantity`: the requested quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
 * `deliverySchedule.status`: The logistics status of this delivery line according to the buyer. The `deliverySchedule.position` MUST be set when providing `status`.
 
 {% hint style="warning" %}
-`deliverySchedule.position` should be unique within the delivery schedule and never change. Never renumber or re-use `deliverySchedule.position`s.
+`deliverySchedule.position` should be unique within the delivery schedule and never change. Never renumber or re-use a `deliverySchedule.position`.
+
+The buyer must provide a `deliverySchedule.position` when providing the `status` field and to be able to receive additional logistics fields.
 {% endhint %}
 
 {% hint style="info" %}

--- a/buyer/receive/README.md
+++ b/buyer/receive/README.md
@@ -167,6 +167,10 @@ Only if the process status is `Confirmed` the line is agreed between buyer and s
 
 ### Logistics fields
 
+{% hint style="warning" %}
+The buyer must provide a `deliverySchedule.position` when sending an order to be able to receive additional logistics fields.
+{% endhint %}
+
 These additional logistics fields are only available in the order line level delivery schedule:
 
 * `deliverySchedule.status`: the optional delivery line's [logistics status](./#logistics-status).


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-7159

### Scope
This PR gives an additional clarification about the mandatory delivery line position

https://tradecloud.gitbook.io/api/v/TC-7159-delivery-schedule-position-mandatory/buyer/issue#requested-planned-delivery-schedule
https://tradecloud.gitbook.io/api/v/TC-7159-delivery-schedule-position-mandatory/buyer/receive#logistics-fields

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
