### PR TITLE
[TC-7373] Fix prod environment docs links

### DIFF
--- a/api/environments.md
+++ b/api/environments.md
@@ -4,7 +4,7 @@ description: Tradecloud API environments available
 
 # Environments
 
-Tradecloud has 3 environments available for customers:
+Tradecloud has two environments available for customers:
 
 * [Production live environment](environments.md#production-environment)
 * [Acceptance test environment](environments.md#acceptance-test-environment)
@@ -17,19 +17,19 @@ It has an availability Service Level Objective of 95% per month.
 
 #### Documentation
 
-You can use the endpoints below to integrate with the production environment. Use [https://api.tradecloud1.com/v2/api-connector/](https://swagger-ui.prod.tradecloud1.com/?url=https://api.tradecloud1.com/v2/api-connector/specs.yaml) to send an order \(response\).
+You can use the endpoints below to integrate with the production environment. Use [https://api.tradecloud1.com/v2/api-connector/](https://swagger-ui.tradecloud1.com/?url=https://api.tradecloud1.com/v2/api-connector/specs.yaml) to send an order \(response\).
 
 You can [use the Swagger UI](tools/swagger-ui.md) to explore and test the Tradecloud API:
 
 | Service | Docs |
 | :--- | :--- |
-| [https://api.tradecloud1.com/v2/api-connector](https://api.tradecloud1.com/v2/api-connector) | [YAML](https://api.tradecloud1.com/v2/api-connector/specs.yaml) / [Swagger UI](https://swagger-ui.prod.tradecloud1.com/?url=https://api.tradecloud1.com/v2/api-connector/specs.yaml) |
-| [https://api.tradecloud1.com/v2/authentication](https://api.tradecloud1.com/v2/authentication) | [YAML](https://api.tradecloud1.com/v2/authentication/specs.yaml) / [Swagger UI](https://swagger-ui.prod.tradecloud1.com/?url=https://api.tradecloud1.com/v2/authentication/specs.yaml) |
-| [https://api.tradecloud1.com/v2/object-storage](https://api.tradecloud1.com/v2/object-storage) | [YAML](https://api.tradecloud1.com/v2/object-storage/specs.yaml) / [Swagger UI](https://swagger-ui.prod.tradecloud1.com/?url=https://api.tradecloud1.com/v2/object-storage/specs.yaml) |
-| [https://api.tradecloud1.com/v2/order](https://api.tradecloud1.com/v2/order) | [YAML](https://api.tradecloud1.com/v2/order/specs.yaml) / [Swagger UI](https://swagger-ui.prod.tradecloud1.com/?url=https://api.tradecloud1.com/v2/order/specs.yaml) |
-| [https://api.tradecloud1.com/v2/order-search](https://api.tradecloud1.com/v2/order-search) | [YAML](https://api.tradecloud1.com/v2/order-search/specs.yaml) / [Swagger UI](https://swagger-ui.prod.tradecloud1.com/?url=https://api.tradecloud1.com/v2/order-search/specs.yaml) |
-| [https://api.tradecloud1.com/v2/order-webhook-client](https://api.tradecloud1.com/v2/order-webhook-client) | [YAML](https://api.tradecloud1.com/v2/order-webhook-client/specs.yaml) / [Swagger UI](https://swagger-ui.prod.tradecloud1.com/?url=https://api.tradecloud1.com/v2/order-webhook-client/specs.yaml) |
-| [https://api.tradecloud1.com/v2/sci-connector](https://api.tradecloud1.com/v2/sci-connector) | [YAML](https://api.tradecloud1.com/v2/sci-connector/specs.yaml) / [Swagger UI](https://swagger-ui.prod.tradecloud1.com/?url=https://api.tradecloud1.com/v2/sci-connector/specs.yaml) |
+| [https://api.tradecloud1.com/v2/api-connector](https://api.tradecloud1.com/v2/api-connector) | [YAML](https://api.tradecloud1.com/v2/api-connector/specs.yaml) / [Swagger UI](https://swagger-ui.tradecloud1.com/?url=https://api.tradecloud1.com/v2/api-connector/specs.yaml) |
+| [https://api.tradecloud1.com/v2/authentication](https://api.tradecloud1.com/v2/authentication) | [YAML](https://api.tradecloud1.com/v2/authentication/specs.yaml) / [Swagger UI](https://swagger-ui.tradecloud1.com/?url=https://api.tradecloud1.com/v2/authentication/specs.yaml) |
+| [https://api.tradecloud1.com/v2/object-storage](https://api.tradecloud1.com/v2/object-storage) | [YAML](https://api.tradecloud1.com/v2/object-storage/specs.yaml) / [Swagger UI](https://swagger-ui.tradecloud1.com/?url=https://api.tradecloud1.com/v2/object-storage/specs.yaml) |
+| [https://api.tradecloud1.com/v2/order](https://api.tradecloud1.com/v2/order) | [YAML](https://api.tradecloud1.com/v2/order/specs.yaml) / [Swagger UI](https://swagger-ui.tradecloud1.com/?url=https://api.tradecloud1.com/v2/order/specs.yaml) |
+| [https://api.tradecloud1.com/v2/order-search](https://api.tradecloud1.com/v2/order-search) | [YAML](https://api.tradecloud1.com/v2/order-search/specs.yaml) / [Swagger UI](https://swagger-ui.tradecloud1.com/?url=https://api.tradecloud1.com/v2/order-search/specs.yaml) |
+| [https://api.tradecloud1.com/v2/order-webhook-client](https://api.tradecloud1.com/v2/order-webhook-client) | [YAML](https://api.tradecloud1.com/v2/order-webhook-client/specs.yaml) / [Swagger UI](https://swagger-ui.tradecloud1.com/?url=https://api.tradecloud1.com/v2/order-webhook-client/specs.yaml) |
+| [https://api.tradecloud1.com/v2/sci-connector](https://api.tradecloud1.com/v2/sci-connector) | [YAML](https://api.tradecloud1.com/v2/sci-connector/specs.yaml) / [Swagger UI](https://swagger-ui.tradecloud1.com/?url=https://api.tradecloud1.com/v2/sci-connector/specs.yaml) |
 
 ### Planned production maintenance
 


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-7373

### Scope
This PR fixes the production links to the YAML and Swagger UI on the environments page (.prod has been removed)

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x]  Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
