### PR TITLE
fix: [TC-8535] Automatically set TcBearer env variable after login

### DIFF
--- a/.gitbook/assets/tradecloud-demo.postman_collection.json
+++ b/.gitbook/assets/tradecloud-demo.postman_collection.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "a501ca22-b32d-42f2-ba74-dd06f84bd31e",
+		"_postman_id": "4b40b0f8-24d5-42fc-8db3-d638073c7eac",
 		"name": "Tradecloud Demo",
 		"description": "This collection contains requests illustrating how to use the Tradecloud API.",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "7528703"
 	},
 	"item": [
 		{
@@ -20,7 +21,7 @@
 									"bearer": [
 										{
 											"key": "token",
-											"value": "",
+											"value": "{{TcBearer}}",
 											"type": "string"
 										}
 									]
@@ -65,7 +66,7 @@
 									"bearer": [
 										{
 											"key": "token",
-											"value": "",
+											"value": "{{TcBearer}}",
 											"type": "string"
 										}
 									]
@@ -101,9 +102,7 @@
 							},
 							"response": []
 						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
+					]
 				},
 				{
 					"name": "Issue an order",
@@ -113,7 +112,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "",
+									"value": "{{TcBearer}}",
 									"type": "string"
 								}
 							]
@@ -159,11 +158,22 @@
 						"type": "string"
 					}
 				]
-			},
-			"protocolProfileBehavior": {}
+			}
 		},
 		{
 			"name": "Login",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// This will set the TcBearer variable that can be used in other requests",
+							"postman.setGlobalVariable(\"TcBearer\",postman.getResponseHeader(\"Set-Authorization\") );"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"auth": {
 					"type": "basic",
@@ -206,7 +216,6 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "611ce9b7-4b3b-4292-b650-be321beb9284",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -216,13 +225,11 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "454caf74-3f0c-4862-aeee-848c5e411469",
 				"type": "text/javascript",
 				"exec": [
 					""
 				]
 			}
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }


### PR DESCRIPTION
And reuse it in other requests

## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-8535

### Scope
This PR updates the postman collection in the API v2 docs to include a "Test" script that will automatically set a `TcBearer` token based on the returned JWT token.
This env variable is then by default used in consecutive requests as bearer token.

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
