### PR TITLE
[TC-8375] Remove `The deliveryOverdue feature is planned`

### DIFF
--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -19,11 +19,6 @@ First choose either the webhook API or the polling API to receive order response
 * `buyerOrder`: the buyer part of the order
 * `supplierOrder`: the supplier part of the order, see below
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
-
-{% hint style="warning" %}
-The`deliveryOverdue`feature is planned and API and documentation may change.
-{% endhint %}
-
 * `status.processStatus`: is the aggregate of all lines' [process statuses](./#process-status).
 * `status.logisticsStatus`: is the aggregate of all lines' [logistics statuses](./#logistics-status).
 * `version`: the  Tradecloud order version number
@@ -61,11 +56,6 @@ The`deliveryOverdue`feature is planned and API and documentation may change.
 * `confirmedLine`: the order line as agreed between buyer and supplier, see [Confirmed line](./#confirmed-line).
 * `deliverySchedule`: the aggregated delivery schedule lines with logistics info, see [Delivery Schedule](./#delivery-schedule) below.
 * `indicators.deliveryOverdue` is true when the order line is overdue.
-
-{% hint style="warning" %}
-The`deliveryOverdue`feature is planned and API and documentation may change.
-{% endhint %}
-
 * `status.processStatus`: the order line's [process status](./#process-status).
 * `status.logisticsStatus`: the order line's [logistics status](./#logistics-status).
 * `eventDates`: some key line event date/times

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -19,11 +19,6 @@ First choose either the webhook API or the polling API to receive orders:
 * `buyerOrder`: the buyer part of the order, see below.
 * `supplierOrder`: the supplier part of the order.
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
-
-{% hint style="warning" %}
-The`deliveryOverdue`feature is planned and API and documentation may change.
-{% endhint %}
-
 * `status.processStatus`: is the aggregate of all lines [process status](./#process-status).
 * `status.logisticsStatus`: is the aggregate of all lines [logistics status](./#logistics-status).
 * `version`: the  Tradecloud order version number.
@@ -67,11 +62,6 @@ The `buyerAccountNumber` should be set on forehand in the Tradecloud connection 
 * `confirmedLine`: the order line as agreed between buyer and supplier, see [Confirmed line](./#confirmed-line) below.
 * `deliverySchedule`: the aggregated delivery schedule line with logistics info, see [Delivery Schedule](./#delivery-schedule) below.
 * `indicators.deliveryOverdue` is true when the order line is overdue.
-
-{% hint style="warning" %}
-The`deliveryOverdue`feature is planned and API and documentation may change.
-{% endhint %}
-
 * `status.processStatus`: the order line's [process status](./#process-status).
 * `status.logisticsStatus`: the order line's [logistics status](./#logistics-status).
 * `eventDates`: some key line event date/times.


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-8375

Please review: https://app.gitbook.com/s/-LNyJ9UuwLCjTvA2sqQR-887967055/~/revisions/uAEcwmFuluqezQFGmw1G/

### Scope
This PR removes the `The deliveryOverdue feature is planned` texts as this feature is released.
Note that `deliveryOverdue` on delivery line level not has been added to the webhook.
This may be added when migrating the webhook connector to Scala

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
