### PR TITLE
[TC-8500] Add transport mode

### DIFF
--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -172,12 +172,13 @@ The webhook `orderEvent.lines.itemDetails.mergedItemDetails` will contain the me
 * `position`: the optional position in the delivery schedule. Not to be confused with the `lines.position`.
 * `date`: the requested delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
 * `quantity`: the requested quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
-* `status`: The logistics status of this delivery line according to the buyer. The `deliverySchedule.position` MUST be set when providing `status`.
+* `status`: The logistics status of this delivery line according to the buyer.
+* `transportMode`: The Mode of Transport used for the delivery of goods as required by the buyer. UNECE.org Recommendation 19 is advised for Mode of Transport values.
 
 {% hint style="warning" %}
-`deliverySchedule.position` should be unique within the delivery schedule and never change. Never renumber or re-use a `deliverySchedule.position`.
+`deliverySchedule.position` must be unique within the delivery schedule and never change. Never renumber or re-use a `deliverySchedule.position`.
 
-The buyer must provide a `deliverySchedule.position` when providing the `status` field and to be able to receive additional logistics fields.
+The buyer must provide a `deliverySchedule.position` when providing the `status` or `transportMode` fields.
 {% endhint %}
 
 {% hint style="info" %}
@@ -185,9 +186,6 @@ The delivery line logistics status is one of:
 
 * `ReadyToShip`: full quantity ready to be shipped by the supplier
 * `Shipped`: full quantity shipped by the supplier
-
-This logistics status is planned and API and documentation may change:
-
 * `Delivered`: full quantity delivered at the buyer
 {% endhint %}
 


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-8500

### Scope
This PR adds `transportMode` in the `deliverySchedule` in the buyer issue page
(The webhook `deliverySchedule` does not contain `status` and `transportMode`)

Please review https://app.gitbook.com/o/-LNyIUZSvpZWZ81yEr7V/s/-LNyJ9UuwLCjTvA2sqQR-887967055/~/revisions/mHHEL3mpwVojLJ70A9rM/processes/order/buyer/issue#requested-planned-delivery-schedule

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR to 'Reviewer'

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
