### PR TITLE
docs: [TC-8676] List blocked file extensions

### DIFF
--- a/security/documents.md
+++ b/security/documents.md
@@ -5,6 +5,8 @@ Documents that are uploaded to our Object Storage \([buyer](../order/buyer/issue
 We protect your documents and the users that receive your documents as follows:
 
 * Documents can only be uploaded or downloaded through an [encrypted connection](encryption.md)
+* The following file extensions are blocked by our API:   
+    `.ade`, `.adp`, `.apk`, `.appx`, `.appxbundle`, `.bat`, `.cab`, `.chm`, `.cmd`, `.com`, `.cpl`, `.diagcab`, `.diagcfg`, `.diagpack`, `.dll`, `.dmg`, `.ex`, `.ex_`, `.exe`, `.hta`, `.img`, `.ins`, `.iso`, `.isp`, `.jar`, `.jnlp`, `.js`, `.jse`, `.lib`, `.lnk`, `.mde`, `.msc`, `.msi`, `.msix`, `.msixbundle`, `.msp`, `.mst`, `.nsh`, `.pif`, `.ps1`, `.scr`, `.sct`, `.shb`, `.sys`, `.vb`, `.vbe`, `.vbs`, `.vhd`, `.vxd`, `.wsc`, `.wsf`, `.wsh`, `.xll`
 * Once a document is uploaded:
   * It is stored on \(hardware-level\) encrypted disks. 
   * it is stored spanning multiple EU data centers. 


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-8676

### Scope
This PR documents the list of file extensions that are blocked by the `object-storage`, as listing them in the API specs results in messy specs.

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [ ] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
