### PR TITLE
[TC-8558] Relax order update rule

### DIFF
--- a/api/rules.md
+++ b/api/rules.md
@@ -91,7 +91,7 @@ Resending periodically will result in processing delays and excessive network, s
 
 ### The order or order response should only contain new or changed lines
 
-The order or response should only contain **order lines** that are **new or changed**.
+The order or response should preferable only contain **order lines** that are **new or changed**. But you can also send all lines anyway.
 
 Sending all lines may result in processing delays and unnecessary network, server and storage resource usage.
 

--- a/order/buyer/update.md
+++ b/order/buyer/update.md
@@ -6,10 +6,6 @@ description: How to update an existing purchase order as a buyer
 
 As buyer you can send either a [new](issue/) or updated purchase order to Tradecloud.
 
-{% hint style="warning" %}
-The order should only contain **order lines** that are **new or changed**. Sending an unchanged order line could trigger an unexpected line status change in Tradecloud.
-{% endhint %}
-
 ## Send an updated order to Tradecloud
 
 As a buyer you can send an updated purchase order to Tradecloud.
@@ -27,7 +23,9 @@ If an order line has order process status `Issued` or `In Progress` and it is up
 Using the `/api-connector/order` API method is the same as when [sending a new order](issue/) with additional JSON objects as mentioned below. Tradecloud will update the order based on the `purchaseOrderNumber` and will add or update lines, delivery schedules and delivery histories where needed. Lines will be matched based on `lines.position`, `deliverySchedule.position` and `deliveryHistory.position`.
 
 {% hint style="info" %}
-The update is event oriented, you only have to send the lines new or updated. But you can also send all lines anyway.
+The order update should preferable only contain **order lines** that are **new or changed**. But you can also send all lines anyway.
+
+Sending all lines may result in processing delays and unnecessary network, server and storage resource usage.
 {% endhint %}
 
 ## Additional fields


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-8558

https://app.intercom.com/a/inbox/nel1ptj2/inbox/admin/2093215/conversation/106384000099046

https://app.gitbook.com/o/-LNyIUZSvpZWZ81yEr7V/s/-LNyJ9UuwLCjTvA2sqQR-887967055/~/revisions/J1gG1glifd2ESGjTV4fI/processes/order/buyer/update

### Scope
This PR makes the order update rule consistent: it is preferable, but not mandatory, to send only new or updated lines.

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
