### PR TITLE
[TC-8713] [TC-9481] [TC-9467] Explain how to handle open requests using polling

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -52,6 +52,7 @@
   * [Supplier order process](order/supplier/README.md)
     * [Receive an order](order/supplier/receive/README.md)
       * [Download a document attached to an order](order/supplier/receive/download-document.md)
+      * [Simple order event](order/supplier/receive/simple-order-event.md)
     * [Send order response](order/supplier/send-order-response/README.md)
       * [Attach a document to an order response](order/supplier/send-order-response/attach-document.md)
     * [Reopen an order](order/supplier/reopen.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,6 +17,8 @@
     * [Postman](api/tools/postman.md)
     * [.NET SDK](api/tools/.net-sdk.md)
   * [Webhook versus polling](api/webhook-vs-polling.md)
+    * [Polling usage](api/polling/README.md)
+    * [Polling echo](api/polling/echo.md)
   * [Delivery schedule](api/delivery-schedule.md)
 * [Security](security/README.md)
   * [Security overview](security/security-overview.md)

--- a/api/delivery-schedule.md
+++ b/api/delivery-schedule.md
@@ -17,6 +17,7 @@ Other ERP systems can only work with only one delivery per order line.
 Use the Tradecloud [**simple** delivery schedule](#simple-delivery-schedule) in this case.
 
 ## Native delivery schedule
+
 The default is to receive the native delivery schedule. The "Orders Webhook Integration" setting "My system supports" must be set to the default "**Multiple delivery lines per order line**".
 
 Use the `orderEvent` field of the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
@@ -37,6 +38,7 @@ The `position` may be unassigned in case of a delivery line split by a supplier.
 * `transportMode`: The Mode of Transport used for the delivery of goods as required by the buyer. [UNECE.org Recommendation 19](https://tfig.unece.org/contents/recommendation-19.htm) is advised for Codes for Modes of Transport.
 
 ## Simple delivery schedule
+
 To receive the simple delivery schedule you must have the "Orders Webhook Integration" setting "My system supports" set to "**Only one delivery line per order line**".
 
 Use the `simpleOrderEvent` field of the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
@@ -64,8 +66,10 @@ The simple delivery schedule is only supported by the POST webhook API, and not 
 
 ## Logistics status
 
-The logistics status is one of:
+The **logistics** status is one of:
 
-* `ReadyToShip`: full quantity ready to be shipped by the supplier
-* `Shipped`: full quantity shipped by the supplier
-* `Delivered`: full quantity delivered at the buyer
+* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
+* `Produced`: the delivery line quantity is produced by the supplier
+* `ReadyToShip`: the delivery line quantity is ready to be shipped by the supplier
+* `Shipped`: the delivery line quantity is shipped by the supplier
+* `Delivered`: the delivery line quantity is delivered at the buyer

--- a/api/delivery-schedule.md
+++ b/api/delivery-schedule.md
@@ -66,7 +66,7 @@ The simple delivery schedule is only supported by the POST webhook API, and not 
 
 ## Logistics status
 
-The **logistics** status is one of:
+The logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the delivery line quantity is produced by the supplier

--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -33,7 +33,7 @@ Use the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://
 Process the fetched new or updated orders or shipments.
 
 {% hint style="warning" %}
-You may receive any order or shipment change, including echoed changes from your ERP system. How to handle your own open request is explained in [Polling requests](requests.md):
+You may receive any order or shipment change, including echoed changes from your ERP system. How to handle your own open request is explained in [Polling echo](echo.md):
 {% endhint %}
 
 See the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint:

--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -11,9 +11,9 @@ The polling API is an alternative for the webhook API. The pro's and cons are ex
 
 This page explains the polling pattern usage, which consists of 3 steps:
 
-1. Every polling period, fetch order or shipments which are changed after last time.
-2. Process the fetched new or updated orders or shipments.
-3. Persist the `data.lastUpdatedAt` for the next polling request
+1. Every polling period, fetch the orders or shipments which are changed after last time.
+2. Process the fetched, either new or updated, orders or shipments.
+3. Persist the lastest `data.lastUpdatedAt` for the next polling request
 
 ## Step 1. Fetch updated orders or shipments periodically
 
@@ -33,18 +33,18 @@ Use the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://
 Process the fetched new or updated orders or shipments.
 
 {% hint style="warning" %}
-You may receive any order or shipment change, including echoed changes from your ERP system. How to handle your own open request is explained in [Polling echo](echo.md):
+You may receive any order or shipment change, including echoed changes from your ERP system. How to handle your own open request is explained in [Polling echo](echo.md).
 {% endhint %}
 
-See the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint:
+When using the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint:
 
-* Use the `data.lines.lastUpdatedAt` field to filter the order lines that have been changed, when `lines.lastUpdatedAt` is greater than `lastUpdatedAfter`.
-* Use the `data.lines.status` fields to filter the order lines on `processStatus`, `inProgressStatus`, `logisticsStatus` and `deliveryLineStatus` fields.
+* Optionally use the `data.lines.lastUpdatedAt` field to filter the order lines that have been changed, when `lines.lastUpdatedAt` is greater than `lastUpdatedAfter`.
+* Optionally use the `data.lines.status` fields to filter the order lines on `processStatus`, `inProgressStatus`, `logisticsStatus` and `deliveryLineStatus` fields.
 
-See the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/searchShipmentsRoute) endpoint:
+When using the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/searchShipmentsRoute) endpoint:
 
-* Use the `data.lines.meta.lastUpdatedAt` to filter the shipment lines that have been changed.
-* Use the `data.status` field to filter on shipment process and logistics status sub fields.
+* Optionally use the `data.lines.meta.lastUpdatedAt` to filter the shipment lines that have been changed.
+* Optionally use the `data.status` field to filter on shipment process and logistics status sub fields.
 
 ## Step 3. Persist the `lastUpdatedAt` for the next polling request
 
@@ -52,5 +52,5 @@ Persist the **latest** \(in the last order or shipment in the response body\) `l
 
 * `lastUpdatedAt` has type `String` with format `YYYY-MM-DDThh:mm:ss.SSSZ`, but to keep it simple just store it as a `String`.
 * The latest `lastUpdatedAt` should be stored **persistent**. When your integration is restarted or crashes, `lastUpdatedAt` should still be available.
-* If there is no order in the order or shipment response body, use the same `lastUpdatedAfter` in the next polling request.
-* The very first time, use a date in the past, from the point you want to receive existing order responses.
+* If there is no data in the response body, use the same `lastUpdatedAfter` again in the next polling request.
+* The very first time, use a `lastUpdatedAfter` date in the past, from the point you want to receive existing orders or shipments.

--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -7,7 +7,7 @@ description: >-
 
 The polling API is an alternative for the webhook API. The pro's and cons are explained in:
 
-{% page-ref page="../api/webhook-vs-polling.md" %}
+{% page-ref page="../webhook-vs-polling.md" %}
 
 This page explains the polling pattern usage, which consists of 3 steps:
 

--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -13,14 +13,14 @@ This page explains the polling pattern usage, which consists of 3 steps:
 
 1. Every polling period, fetch order or shipments which are changed after last time.
 2. Process the fetched new or updated orders or shipments.
-3. Persist the `lastUpdatedAt` for the next polling request
+3. Persist the `data.lastUpdatedAt` for the next polling request
 
 ## Step 1. Fetch updated orders or shipments periodically
 
 Fetch every polling period, typically 5 minutes, all orders or shipments which are new or changed after last time.
 
-* Use the latest `lastUpdatedAt` from previous poll request in the `lastUpdatedAfter` filter.
-* Sorting is set automatically to `lastUpdatedAt` order `asc` \(the latest `lastUpdatedAt` will be in the last order or shipment in the response body\)
+* Use the latest `data.lastUpdatedAt` from previous poll request in the `lastUpdatedAfter` filter.
+* Sorting is set automatically to `data.lastUpdatedAt` order `asc` \(the latest `data.lastUpdatedAt` will be in the last order or shipment in the response body\)
 * Set `limit` to the maximum of `100` orders or shipments.
 * Optionally use `offset` for paging, but if you receive more than `100` orders or shipments, it is easier to reduce the polling period, so you receive less orders or shipments per request.
 
@@ -38,13 +38,13 @@ You may receive any order or shipment change, including echoed changes from your
 
 See the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint:
 
-* Use the `lines.lastUpdatedAt` field to filter the order lines that have been changed.
-* Use the `status` field to filter on order process and logistics status.
+* Use the `data.lines.lastUpdatedAt` field to filter the order lines that have been changed, when `lines.lastUpdatedAt` is greater than `lastUpdatedAfter`.
+* Use the `data.lines.status` fields to filter the order lines on `processStatus`, `inProgressStatus`, `logisticsStatus` and `deliveryLineStatus` fields.
 
 See the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/searchShipmentsRoute) endpoint:
 
-* Use the `lines.meta.lastUpdatedAt` to filter the shipment lines that have been changed.
-* Use the `status` field to filter on shipment process and logistics status.
+* Use the `data.lines.meta.lastUpdatedAt` to filter the shipment lines that have been changed.
+* Use the `data.status` field to filter on shipment process and logistics status sub fields.
 
 ## Step 3. Persist the `lastUpdatedAt` for the next polling request
 

--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -7,22 +7,24 @@ description: >-
 
 The polling API is an alternative for the webhook API. The pro's and cons are explained in:
 
-{% page-ref page="api/webhook-vs-polling.md" %}
+{% page-ref page="../api/webhook-vs-polling.md" %}
 
 This page explains the polling pattern usage, which consists of 3 steps:
 
-1. Every polling period, fetch the orders or shipments which are changed after last time.
+1. Fetch the orders or shipments which are changed after last time.
 2. Process the fetched, either new or updated, orders or shipments.
-3. Persist the lastest `data.lastUpdatedAt` for the next polling request
+3. Persist the latest `data.lastUpdatedAt`.
 
 ## Step 1. Fetch updated orders or shipments periodically
 
-Fetch every polling period, typically 5 minutes, all orders or shipments which are new or changed after last time.
+Every polling period, fetch all orders or shipments which are new or changed after last time. A polling period is typically 5 minutes.
 
 * Use the latest `data.lastUpdatedAt` from previous poll request in the `lastUpdatedAfter` filter.
-* Sorting is set automatically to `data.lastUpdatedAt` order `asc` \(the latest `data.lastUpdatedAt` will be in the last order or shipment in the response body\)
+* Sorting is set to `data.lastUpdatedAt` (`asc`) by default when the `lastUpdatedAfter` filter is applied. The last updated order or shipment will be ordered last in the response body.
 * Set `limit` to the maximum of `100` orders or shipments.
-* Optionally use `offset` for paging, but if you receive more than `100` orders or shipments, it is easier to reduce the polling period, so you receive less orders or shipments per request.
+* If the response body contains a `total` of more than `100`, it means that not all recently updated orders or shipments were returned. You can either:
+  * Decrease the polling period (advised)
+  * Use `offset` for paging, to receive the next 100 orders or shipments.
 
 Use the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint for polling orders.
 
@@ -38,7 +40,7 @@ You may receive any order or shipment change, including echoed changes from your
 
 When using the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint:
 
-* Optionally use the `data.lines.lastUpdatedAt` field to filter the order lines that have been changed, when `lines.lastUpdatedAt` is greater than `lastUpdatedAfter`.
+* Optionally use the `data.lines.lastUpdatedAt` field to filter the order lines that have been changed: Only consider lines where `lines.lastUpdatedAt` is after the `lastUpdatedAfter` filter value.
 * Optionally use the `data.lines.status` fields to filter the order lines on `processStatus`, `inProgressStatus`, `logisticsStatus` and `deliveryLineStatus` fields.
 
 When using the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/searchShipmentsRoute) endpoint:
@@ -53,4 +55,4 @@ Persist the **latest** \(in the last order or shipment in the response body\) `l
 * `lastUpdatedAt` has type `String` with format `YYYY-MM-DDThh:mm:ss.SSSZ`, but to keep it simple just store it as a `String`.
 * The latest `lastUpdatedAt` should be stored **persistent**. When your integration is restarted or crashes, `lastUpdatedAt` should still be available.
 * If there is no data in the response body, use the same `lastUpdatedAfter` again in the next polling request.
-* The very first time, use a `lastUpdatedAfter` date in the past, from the point you want to receive existing orders or shipments.
+* In the very first polling request, set the `lastUpdatedAfter` to a date in the past from which you want to receive existing orders or shipments.

--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -1,0 +1,56 @@
+---
+description: >-
+  How to use the polling pattern.
+---
+
+# Polling usage
+
+The polling API is an alternative for the webhook API. The pro's and cons are explained in:
+
+{% page-ref page="api/webhook-vs-polling.md" %}
+
+This page explains the polling pattern usage, which consists of 3 steps:
+
+1. Every polling period, fetch order or shipments which are changed after last time.
+2. Process the fetched new or updated orders or shipments.
+3. Persist the `lastUpdatedAt` for the next polling request
+
+## Step 1. Fetch updated orders or shipments periodically
+
+Fetch every polling period, typically 5 minutes, all orders or shipments which are new or changed after last time.
+
+* Use the latest `lastUpdatedAt` from previous poll request in the `lastUpdatedAfter` filter.
+* Sorting is set automatically to `lastUpdatedAt` order `asc` \(the latest `lastUpdatedAt` will be in the last order or shipment in the response body\)
+* Set `limit` to the maximum of `100` orders or shipments.
+* Optionally use `offset` for paging, but if you receive more than `100` orders or shipments, it is easier to reduce the polling period, so you receive less orders or shipments per request.
+
+Use the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint for polling orders.
+
+Use the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/searchShipmentsRoute) endpoint for polling shipments.
+
+## Step 2. Process the orders or shipments in the search response body
+
+Process the fetched new or updated orders or shipments.
+
+{% hint style="warning" %}
+You may receive any order or shipment change, including echoed changes from your ERP system. How to handle your own open request is explained in [Polling requests](requests.md):
+{% endhint %}
+
+See the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint:
+
+* Use the `lines.lastUpdatedAt` field to filter the order lines that have been changed.
+* Use the `status` field to filter on order process and logistics status.
+
+See the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/searchShipmentsRoute) endpoint:
+
+* Use the `lines.meta.lastUpdatedAt` to filter the shipment lines that have been changed.
+* Use the `status` field to filter on shipment process and logistics status.
+
+## Step 3. Persist the `lastUpdatedAt` for the next polling request
+
+Persist the **latest** \(in the last order or shipment in the response body\) `lastUpdatedAt` to be used as `lastUpdatedAfter` in the next polling request.
+
+* `lastUpdatedAt` has type `String` with format `YYYY-MM-DDThh:mm:ss.SSSZ`, but to keep it simple just store it as a `String`.
+* The latest `lastUpdatedAt` should be stored **persistent**. When your integration is restarted or crashes, `lastUpdatedAt` should still be available.
+* If there is no order in the order or shipment response body, use the same `lastUpdatedAfter` in the next polling request.
+* The very first time, use a date in the past, from the point you want to receive existing order responses.

--- a/api/polling/echo.md
+++ b/api/polling/echo.md
@@ -5,14 +5,10 @@ description: >-
 
 # Handle echoed changes when using polling
 
-When your order update or order response results in an open request, asking either supplier or buyer to approve the change, there is a functional consideration that requires careful attention, if your ERP system does not make a distinction between `requested` versus `confirmed` fields such as delivery date or prices:
+When your order update or order response results in an **open request**, asking the other party to approve the change, there is a functional consideration that requires careful attention, if your ERP system **does not make a distinction between `requested` versus `confirmed` fields** such as delivery date, quantity or prices:
 
-The fields `lines.deliverySchedule`, `lines.prices` and `lines.chargeLines` will still contain the issued or confirmed values, and not the changed values sent by your ERP system. In the next polling request, when these issued or confirmed values are processed by your ERP system, they will overwrite the changed values in your ERP system.
+In this case the fields `lines.deliverySchedule`, `lines.prices` and `lines.chargeLines` will still contain the issued or confirmed values, and not the changed values just sent by your ERP system. In the next polling request, when these issued or confirmed values are processed by your ERP system, they will revert the changed values in your ERP system. These fields have to be ignored when:
 
-The fields `lines.deliveryScheduleIncludingRequest`, `lines.pricesIncludingRequest` and `lines.chargeLinesIncludingRequest` will reflect the changed values of the open request. When these values are processed by your ERP system, they will not overwrite the changed values in your ERP system.
-
-Wether to use the `includingRequests` fields or ignore the order line update depends on the request status:
-
-For buyers, if the [`lines.buyerLine.requests.reopenRequest.status`](../../order/buyer/receive/README.md#buyer-requests) is [`Open`](../../order/buyer/receive/README.md#request-status) then use the `includingRequests` fields.
-
-For suppliers, if the [`lines.supplier.requests.proposal.status` or `lines.supplier.requests.reopenRequest.status`](../../order/supplier/receive/README.md#supplier-requests) is [`Open`](../../order/supplier/receive/README.md#request-status) then use the `includingRequests` fields.
+* In general, when [`lines.status.ProcessStatus`](../../order/buyer/receive/README.md#line-process-status) is `InProgress`.
+* Or more fine grained, if you are a buyer and the [`lines.status.inProgressStatus`](../../order/buyer/receive/README.md#line-in-progress-status) is `OpenBuyerReopenRequest`.
+* Or if you are a supplier and the [`lines.status.inProgressStatus`](../../order/supplier/receive/README.md#line-in-progress-status) is either `OpenSupplierProposal` or `OpenSupplierReopenRequest`.

--- a/api/polling/echo.md
+++ b/api/polling/echo.md
@@ -1,14 +1,14 @@
 ---
 description: >-
-  How to handle echoed changes in an open request when using polling
+  How to handle echoed changes in case of an open request when using polling
 ---
 
 # Handle echoed changes when using polling
 
-When your order update or order response results in an **open request**, asking the other party to approve the change, there is a functional consideration that requires careful attention, if your ERP system **does not make a distinction between `requested` versus `confirmed` fields** such as delivery date, quantity or prices:
+When your order update or order response results in an **open request**, asking the other party to approve the change, there is a functional consideration that requires careful attention, if your ERP system **does not make a distinction between `requested` versus `confirmed` fields**:
 
-In this case the fields `lines.deliverySchedule`, `lines.prices` and `lines.chargeLines` will still contain the issued or confirmed values, and not the changed values just sent by your ERP system. In the next polling request, when these issued or confirmed values are processed by your ERP system, they will revert the changed values in your ERP system. These fields have to be ignored when:
+In this case the fields `lines.deliverySchedule`, `lines.prices` and `lines.chargeLines` will still contain the issued or confirmed values, and not the changed values just sent by your ERP system. In the next polling request, when these old values are processed by your ERP system, they will revert the changed values in your ERP system. The solution is to ignore these fields in your polling integration when there is an open request:
 
-* In general, when [`lines.status.ProcessStatus`](../../order/buyer/receive/README.md#line-process-status) is `InProgress`.
-* Or more fine grained, if you are a buyer and the [`lines.status.inProgressStatus`](../../order/buyer/receive/README.md#line-in-progress-status) is `OpenBuyerReopenRequest`.
+* Coarse graind: when [`lines.status.ProcessStatus`](../../order/buyer/receive/README.md#line-process-status) is `InProgress`.
+* Or more fine grained: if you are a buyer and the [`lines.status.inProgressStatus`](../../order/buyer/receive/README.md#line-in-progress-status) is `OpenBuyerReopenRequest`.
 * Or if you are a supplier and the [`lines.status.inProgressStatus`](../../order/supplier/receive/README.md#line-in-progress-status) is either `OpenSupplierProposal` or `OpenSupplierReopenRequest`.

--- a/api/polling/echo.md
+++ b/api/polling/echo.md
@@ -5,10 +5,14 @@ description: >-
 
 # Handle echoed changes when using polling
 
-When your order update or order response results in an **open request**, asking the other party to approve the change, there is a functional consideration that requires careful attention, if your ERP system **does not make a distinction between `requested` versus `confirmed` fields**:
+An order update or order response can result in an **open request**, where the other party is asked to approve changes. 
 
-In this case the fields `lines.deliverySchedule`, `lines.prices` and `lines.chargeLines` will still contain the issued or confirmed values, and not the changed values just sent by your ERP system. In the next polling request, when these old values are processed by your ERP system, they will revert the changed values in your ERP system. The solution is to ignore these fields in your polling integration when there is an open request:
+In this case, there is a functional consideration that requires careful attention, if your ERP system **does not make a distinction between `requested` versus `confirmed` fields**:
 
-* Coarse graind: when [`lines.status.ProcessStatus`](../../order/buyer/receive/README.md#line-process-status) is `InProgress`.
-* Or more fine grained: if you are a buyer and the [`lines.status.inProgressStatus`](../../order/buyer/receive/README.md#line-in-progress-status) is `OpenBuyerReopenRequest`.
-* Or if you are a supplier and the [`lines.status.inProgressStatus`](../../order/supplier/receive/README.md#line-in-progress-status) is either `OpenSupplierProposal` or `OpenSupplierReopenRequest`.
+In this case the fields `lines.deliverySchedule`, `lines.prices` and `lines.chargeLines` will still contain the issued or confirmed values, and not the changed values just sent by your ERP system. In the next polling request, when these old values are processed by your ERP system, they may revert the changed values in your ERP system.
+
+This can be solved by ignoring the order or response update in your polling integration when there is an open request:
+
+* When you do not process open requests at all: ignore the order/response update when [`lines.status.ProcessStatus`](../../order/buyer/receive/README.md#line-process-status) is `InProgress`.
+* When you are a buyer and and you process supplier requests: ignore the response update when [`lines.status.inProgressStatus`](../../order/buyer/receive/README.md#line-in-progress-status) is `OpenBuyerReopenRequest`.
+* When you are a supplier and and you process buyer requests: ignore the order update when [`lines.status.inProgressStatus`](../../order/supplier/receive/README.md#line-in-progress-status) is either `OpenSupplierProposal` or `OpenSupplierReopenRequest`.

--- a/api/polling/echo.md
+++ b/api/polling/echo.md
@@ -5,4 +5,14 @@ description: >-
 
 # Handle echoed changes when using polling
 
-Placeholder to test links
+When your order update or order response results in an open request, asking either supplier or buyer to approve the change, there is a functional consideration that requires careful attention, if your ERP system does not make a distinction between `requested` versus `confirmed` fields such as delivery date or prices:
+
+The fields `lines.deliverySchedule`, `lines.prices` and `lines.chargeLines` will still contain the issued or confirmed values, and not the changed values sent by your ERP system. In the next polling request, when these issued or confirmed values are processed by your ERP system, they will overwrite the changed values in your ERP system.
+
+The fields `lines.deliveryScheduleIncludingRequest`, `lines.pricesIncludingRequest` and `lines.chargeLinesIncludingRequest` will reflect the changed values of the open request. When these values are processed by your ERP system, they will not overwrite the changed values in your ERP system.
+
+Wether to use the `includingRequests` fields or ignore the order line update depends on the request status:
+
+For buyers, if the [`lines.buyerLine.requests.reopenRequest.status`](../../order/buyer/receive/README.md#buyer-requests) is [`Open`](../../order/buyer/receive/README.md#request-status) then use the `includingRequests` fields.
+
+For suppliers, if the [`lines.supplier.requests.proposal.status` or `lines.supplier.requests.reopenRequest.status`](../../order/supplier/receive/README.md#supplier-requests) is [`Open`](../../order/supplier/receive/README.md#request-status) then use the `includingRequests` fields.

--- a/api/polling/echo.md
+++ b/api/polling/echo.md
@@ -1,0 +1,8 @@
+---
+description: >-
+  How to handle echoed changes in an open request when using polling
+---
+
+# Handle echoed changes when using polling
+
+Placeholder to test links

--- a/api/rules.md
+++ b/api/rules.md
@@ -68,11 +68,11 @@ Tradecloud may respond with [HTTP Status Code 429](https://tools.ietf.org/html/r
 
 The Tradecloud [environments](environments.md) do not have an availability SLO of 100%. If Tradecloud is temporarily unavailable, it is the API client's responsibility to queue the message and automatically retry with exponential backoff till Tradecloud is available again. An alternative is to warn the ERP user, who is trying to send the message to Tradecloud, so the user can manually retry later.
 
-If Tradecloud responds with either: 
+If Tradecloud responds with either:
 
-- a HTTP Status Code 5xx Server Error or
-- [HTTP Status Code 429](https://tools.ietf.org/html/rfc6585#section-4) `Too Many Requests` or 
-- the requests does time out (currently 5 secs. at Tradecloud API side)
+* a HTTP Status Code 5xx Server Error or
+* [HTTP Status Code 429](https://tools.ietf.org/html/rfc6585#section-4) `Too Many Requests` or 
+* the requests does time out (currently 5 secs. at Tradecloud API side)
   
 Then the client must automatically retry, using an exponential backoff strategy, or use a manual retry strategy. 
 The [Exponential Backoff Calculator](http://backoffcalculator.com/?interval=5&rate=2&attempts=5) is handy to verify the retry plan.
@@ -99,16 +99,16 @@ The TOTAL number of objects is limited to 100 objects per collection by default.
 
 Examples are:
 
-- 100 documents in total per order 
-- 100 documents in total per order line
-- 100 delivery lines per delivery schedule
-- 100 delivery lines per delivery history
+* 100 documents in total per order 
+* 100 documents in total per order line
+* 100 delivery lines per delivery schedule
+* 100 delivery lines per delivery history
 
 Exceptions are:
 
-- 500 lines in total per order 
-- 500 lines in total per shipment
-- 500 lines in total per supplier forecast
+* 500 lines in total per order 
+* 500 lines in total per shipment
+* 500 lines in total per supplier forecast
 
 ## Orders and lines
 

--- a/api/webhook-vs-polling.md
+++ b/api/webhook-vs-polling.md
@@ -127,8 +127,8 @@ Con's:
 
 For polling usage see:
 
-{% page-ref page="api/polling/README.md" %}
+{% page-ref page="polling/README.md" %}
 
 For handling echoed changes from your ERP system see:
 
-{% page-ref page="api/polling/echo.md" %}
+{% page-ref page="polling/echo.md" %}

--- a/api/webhook-vs-polling.md
+++ b/api/webhook-vs-polling.md
@@ -119,44 +119,17 @@ Con's:
 
 * Not real time, a polling period is typically 5 mins.
 * You need to build or configure a periodic polling pattern at your side.
-* You cannot filter on which order or shipment events to act on, you will receive any order or shipment change.
+* You cannot filter on which order or shipment events to act on, you will receive any order or shipment change, including echoed changes from your ERP system.
 * You cannot see what order or shipment event happened, multiple events may have happened.
 * You cannot receive the simple delivery schedule.
 * You cannot choose XML, but must use JSON.
 {% endhint %}
 
-### Polling usage
+For polling usage see:
 
-#### Step 1. Fetch updated orders or shipments periodically
+{% page-ref page="api/polling/README.md" %}
 
-Fetch every polling period, typically 5 minutes, all orders or shipments which are new or changed since last date time.
+For handling echoed changes from your ERP system see:
 
-* Use the latest `lastUpdatedAt` from previous poll request in the `lastUpdatedSince` filter.
-* Sorting is set automatically to `lastUpdatedAt` order `asc` \(the latest `lastUpdatedAt` will be in the last order or shipment in the response body\)
-* Set `limit` to the maximum of `100` orders or shipments.
-* Optionally use `offset` for paging, but if you receive more than `100` orders or shipments, it is easier to reduce the polling period, so you receive less orders or shipments per request.
+{% page-ref page="api/polling/echo.md" %}
 
-Use the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint for polling orders.
-
-Use the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/searchShipmentsRoute) endpoint for polling shipments.
-
-#### Step 2. Process the orders or shipments in the search response body
-
-See the [Search orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/searchRoute) endpoint:
-
-* Use the `lines.lastUpdatedAt` field to filter the order lines that have been changed.
-* Use the `status` field to filter on order process and logistics status.
-
-See the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/searchShipmentsRoute) endpoint:
-
-* Use the `lines.meta.lastUpdatedAt` to filter the shipment lines that have been changed.
-* Use the `status` field to filter on shipment process and logistics status.
-
-#### Step 3. Store the `lastUpdatedAt` for the next polling request
-
-Store the **latest** \(in the last order or shipment in the response body\) `lastUpdatedAt` to be used as `lastUpdatedSince` in the next polling request.
-
-* `lastUpdatedAt` has type `String` with format `YYYY-MM-DDThh:mm:ss.SSSZ`, but to keep it simple just store it as a `String`.
-* The latest `lastUpdatedAt` should be stored **persistent**. When your integration is restarted or crashes, `lastUpdatedAt` should still be available.
-* If there is no order in the order or shipment response body, use the same `lastUpdatedSince` in the next polling request.
-* The very first time, use a date in the past, from the point you want to receive existing order responses.

--- a/order/buyer/README.md
+++ b/order/buyer/README.md
@@ -20,7 +20,7 @@ Additionally, you can [Download a document attached to an order response](receiv
 
 ## Optional step 3. Add the logistical status of goods to order update
 
-You can [Add the logistical status of goods to order update](update.md#logistics-status-in-the-planned-delivery-schedule)
+You can [Add the logistical status of goods to the order update](update.md#logistics-status-in-the-planned-delivery-schedule)
 
 ## Optional step 4. Add actual delivery history to order update
 

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -84,7 +84,8 @@ The optional buyer, buyer accounting or supplier company party:
 
 ## Lines
 
-`lines`: a purchase order contains one or multiple lines. The total number of lines is limited to 500 lines per order. It is structured as a JSON element in the `lines` JSON array. 
+`lines`: a purchase order contains one or multiple lines. The total number of lines is limited to 500 lines per order. It is structured as a JSON element in the `lines` JSON array.
+
 * `position`: the required line position identifier within the purchase order
 * `row`: the optional row label for this position. Only use a row when there is a distinction between position and row in your ERP system. Do NOT use row as identifier.
 
@@ -95,6 +96,7 @@ The optional buyer, buyer accounting or supplier company party:
 ### Item
 
 `lines.item`: the item \(or article, goods\) to be delivered
+
 * `number`: the item code or number as known in your ERP
 * `revision`: the revision \(or version\) of this item number
 * `name`: the item short name
@@ -135,7 +137,8 @@ Please see this page to choose between the native or simple delivery schedule:
 
 ### Requested prices
 
-`lines.prices`: the requested price. Advised is to provide only `netPrice` for its simplicity, used by most buyers, or alternatively `grossPrice` together with `discountPercentage`. 
+`lines.prices`: the requested price. Advised is to provide only `netPrice` for its simplicity, used by most buyers, or alternatively `grossPrice` together with `discountPercentage`.
+
 * `grossPrice`: the gross price. Use together with `discountPercentage`.
 * `discountPercentage`: the discount percentage. Use together with `grossPrice`.
 * `netPrice`: the net price.
@@ -151,6 +154,7 @@ Please see this page to choose between the native or simple delivery schedule:
 ### Requested charge lines
 
 `lines.chargeLines`: the requested additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
+
 * `position`: the position used to identify a charge line.
 * `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
 * `chargeDescription`: a mandatory free text description, like "Transport costs".

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -30,7 +30,6 @@ This page assumes you either chose the native delivery schedule using the `order
 * `orderId` (in case of an `OrderEvent`): the Tradecloud order identifier
 * `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order)
 * `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
-* `lines`: one or more lines of the order, see [Order lines](#order-lines)
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
 * `status.processStatus`: is the aggregate of all lines [Order process statuses](#order-process-status).
 * `status.logisticsStatus`: is the aggregate of all lines [Order logistics statuses](#order-logistics-status).

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -18,11 +18,11 @@ If you choose the POST webhook API, you may choose between the native or simple 
 
 {% page-ref page="../../../api/delivery-schedule.md" %}
 
-When choosing the simple delivery schedule and using the `simpleOrderEvent` please continue on:
+When choosing the simple delivery schedule with the `simpleOrderEvent` please continue on:
 
 {% page-ref page="simple-order-event.md" %}
 
-## `orderEvent` or `order`
+## `orderEvent` or `order` header
 
 This page assumes you either chose the native delivery schedule using the `orderEvent` webhook API or the `order` polling API.
 
@@ -66,7 +66,7 @@ The order status is the aggregation of all the lines statuses.
 #### Order process status
 
 {% hint style="info" %}
-The order **process** status is one of:
+The order process status is one of:
 
 * `Issued`: the order is \(re\)issued by the buyer.
 * `InProgress`: the order is under negotiation between buyer and supplier
@@ -79,7 +79,7 @@ The order **process** status is one of:
 #### Order logistics status
 
 {% hint style="info" %}
-The order **logistics** status is one of:
+The order logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the order full quantity is produced by the supplier
@@ -89,7 +89,7 @@ The order **logistics** status is one of:
 * `Cancelled`: the order is cancelled by the buyer
 {% endhint %}
 
-## Order lines
+## `orderEvent` or `order` lines
 
 `lines` contains one or more order lines:
 
@@ -143,7 +143,7 @@ The order **logistics** status is one of:
 ##### Request status
 
 {% hint style="info" %}
-The **request** status is one of:
+The request status is one of:
 
 * `Open`: Requested by one party. To be approved or rejected by the other party.
 * `Approved`: The request is approved by the other party.
@@ -204,7 +204,7 @@ These additional logistics fields are only available in the order line level del
 ##### Scheduled delivery logistics status
 
 {% hint style="info" %}
-The delivery line **logistics** status is one of:
+The delivery line logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the delivery line quantity is produced by the supplier
@@ -252,7 +252,7 @@ It is advised to only use `netPrice` for its simplicity, or alternatively use `g
 #### Line process status
 
 {% hint style="info" %}
-The line **process** status is one of:
+The line process status is one of:
 
 * `Issued`: the line is \(re\)issued by the buyer
 * `InProgress`: the line is under negotiation between buyer and supplier
@@ -266,7 +266,7 @@ The line **process** status is one of:
 #### Line in Progress status
 
 {% hint style="info" %}
-The line **in progress** status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
+The line in progress status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
 
 * `OpenSupplierProposal`: There is an open proposal from the supplier.
 * `RejectedSupplierProposal`: The proposal from the supplier was rejected and no other requests are open.
@@ -279,7 +279,7 @@ The line **in progress** status is a more fine-grained status when an order line
 #### Line logistics status
 
 {% hint style="info" %}
-The line **logistics** status is one of:
+The line logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the line quantity is produced by the supplier

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -32,8 +32,8 @@ This page assumes you either chose the native delivery schedule using the `order
 * `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
 * `lines`: one or more lines of the order, see [Order lines](#order-lines)
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines' [Order process statuses](#order-process-status).
-* `status.logisticsStatus`: is the aggregate of all lines' [Order logistics statuses](#order-logistics-status).
+* `status.processStatus`: is the aggregate of all lines [Order process statuses](#order-process-status).
+* `status.logisticsStatus`: is the aggregate of all lines [Order logistics statuses](#order-logistics-status).
 * `version`: the Tradecloud order version number
 * `eventDates`: some key order event date/times
 * `meta`: meta information, including source and trace info, about this messsage
@@ -65,6 +65,7 @@ The order status is the aggregation of all the lines statuses.
 
 #### Order process status
 
+{% hint style="info" %}
 The order **process** status is one of:
 
 * `Issued`: the order is \(re\)issued by the buyer.
@@ -73,9 +74,11 @@ The order **process** status is one of:
 * `Rejected`: the order is completely rejected by supplier
 * `Completed`: the order is completed at the buyer
 * `Cancelled`: the order is cancelled by the buyer
+{% endhint %}
 
 #### Order logistics status
 
+{% hint style="info" %}
 The order **logistics** status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
@@ -84,6 +87,7 @@ The order **logistics** status is one of:
 * `Shipped`: the order full quantity is shipped by the supplier
 * `Delivered`: the order full quantity is delivered at the buyer
 * `Cancelled`: the order is cancelled by the buyer
+{% endhint %}
 
 ## Order lines
 
@@ -109,17 +113,7 @@ The order **logistics** status is one of:
 
 `lines.buyerLine` is an echo of your order line fields as explained in [Issue a new order](../issue/#lines)
 
-* `requests`: the buyer can request different delivery schedule, prices and charge lines
-
-#### Buyer requests
-
-`lines.buyerLine.requests.reopenRequest`: the buyer requests to reopen the confirmed order line. The buyer has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
-
-* `deliverySchedule`: the requested alternative delivery schedule
-* `prices`: the requested alternative prices
-* `chargeLines`: the requested alternative charge lines, see [Charge lines](#charge-lines)
-* `reason`: the reason of this request given by the supplier
-* `status`: the [Request status](./#request-status).
+* `position`: the line position within the purchase order
 
 ### Supplier line
 
@@ -155,7 +149,7 @@ The **request** status is one of:
 * `Approved`: The request is approved by the other party.
 * `Rejected`: The request is rejected by the other party.
 * `Closed`: The request is closed because it is not relevant anymore.
-  {% endhint %}
+{% endhint %}
 
 {% hint style="warning" %}
 If the request status is `Open` the other party must approve or reject it.
@@ -209,6 +203,7 @@ These additional logistics fields are only available in the order line level del
 
 ##### Scheduled delivery logistics status
 
+{% hint style="info" %}
 The delivery line **logistics** status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
@@ -216,6 +211,7 @@ The delivery line **logistics** status is one of:
 * `ReadyToShip`: the delivery line quantity is ready to be shipped by the supplier
 * `Shipped`: the delivery line quantity is shipped by the supplier
 * `Delivered`: the delivery line quantity is delivered at the buyer
+{% endhint %}
 
 ### Prices
 
@@ -255,6 +251,7 @@ It is advised to only use `netPrice` for its simplicity, or alternatively use `g
 
 #### Line process status
 
+{% hint style="info" %}
 The line **process** status is one of:
 
 * `Issued`: the line is \(re\)issued by the buyer
@@ -264,8 +261,11 @@ The line **process** status is one of:
 * `Completed`: the line is completed at the buyer
 * `Cancelled`: the line is cancelled by the buyer
 
+{% endhint %}
+
 #### Line in Progress status
 
+{% hint style="info" %}
 The line **in progress** status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
 
 * `OpenSupplierProposal`: There is an open proposal from the supplier.
@@ -274,9 +274,11 @@ The line **in progress** status is a more fine-grained status when an order line
 * `OpenSupplierReopenRequest`: There is an open reopen request from the supplier.
 * `OpenBuyerReopenRequest`: There is an open reopen request from the buyer.
 * `RevertedCompletedLine`: The completion of this line was reverted.
+{% endhint %}
 
 #### Line logistics status
 
+{% hint style="info" %}
 The line **logistics** status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
@@ -285,6 +287,7 @@ The line **logistics** status is one of:
 * `Shipped`: the line quantity shipped by the supplier
 * `Delivered`: the line quantity delivered at the buyer
 * `Cancelled`: the line is cancelled by the buyer
+{% endhint %}
 
 ### Charge lines
 

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -32,8 +32,8 @@ This page assumes you either chose the native delivery schedule using the `order
 * `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
 * `lines`: one or more lines of the order, see [Order lines](#order-lines)
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines' [Process statuses](#process-status).
-* `status.logisticsStatus`: is the aggregate of all lines' [Logistics statuses](#logistics-status).
+* `status.processStatus`: is the aggregate of all lines' [Order process statuses](#order-process-status).
+* `status.logisticsStatus`: is the aggregate of all lines' [Order logistics statuses](#order-logistics-status).
 * `version`: the Tradecloud order version number
 * `eventDates`: some key order event date/times
 * `meta`: meta information, including source and trace info, about this messsage
@@ -59,33 +59,31 @@ This page assumes you either chose the native delivery schedule using the `order
 
 {% page-ref page="download-document.md" %}
 
-### Status
+### Order status
 
-#### Process status
+The order status is the aggregation of all the lines statuses.
 
-{% hint style="info" %}
-Order and line **process** status is one of:
+#### Order process status
 
-* `Issued`: \(re\)issued by the buyer.
-* `InProgress`: under negotiation between buyer and supplier
-* `Confirmed`: agreed between buyer and supplier
-* `Rejected`: rejected by supplier
-* `Completed`: completed at the buyer
-* `Cancelled`: cancelled by the buyer
-  {% endhint %}
+The order **process** status is one of:
 
-#### Logistics status
+* `Issued`: the order is \(re\)issued by the buyer.
+* `InProgress`: the order is under negotiation between buyer and supplier
+* `Confirmed`: the order is completely agreed between buyer and supplier
+* `Rejected`: the order is completely rejected by supplier
+* `Completed`: the order is completed at the buyer
+* `Cancelled`: the order is cancelled by the buyer
 
-{% hint style="info" %}
-Order, line and delivery line **logistics** status is one of:
+#### Order logistics status
+
+The order **logistics** status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
-* `Produced`: full quantity produced by the supplier
-* `ReadyToShip`: full quantity ready to be shipped by the supplier
-* `Shipped`: full quantity shipped by the supplier
-* `Delivered`: full quantity delivered at the buyer
-* `Cancelled`: cancelled by the buyer
-  {% endhint %}
+* `Produced`: the order full quantity is produced by the supplier
+* `ReadyToShip`: the order full quantity is ready to be shipped by the supplier
+* `Shipped`: the order full quantity is shipped by the supplier
+* `Delivered`: the order full quantity is delivered at the buyer
+* `Cancelled`: the order is cancelled by the buyer
 
 ## Order lines
 
@@ -100,8 +98,9 @@ Order, line and delivery line **logistics** status is one of:
 * `prices`: the current prices, see [Prices](#prices) below.
 * `pricesIncludingRequests`: the current prices, including any open supplier or buyer requests, see [Prices](#prices).
 * `indicators.deliveryOverdue` is true when the order line is overdue.
-* `status.processStatus`: the order line's [Process status](#process-status).
-* `status.logisticsStatus`: the order line's [Logistics status](#logistics-status).
+* `status.processStatus`: the order line's [Line process status](#line-process-status).
+* `status.inProgressStatus` the order line's [Line in progress status](#line-in-progress-status).
+* `status.logisticsStatus`: the order line's [Line logistics status](#line-logistics-status).
 * `eventDates`: some key line event date/times
 * `mergedItemDetails`: detailed part information provided by both buyer and supplier, see [Item details](#item-details).
 * `lastUpdatedAt`: is the latest date time the order line has been changed, useful for polling.
@@ -204,9 +203,19 @@ The `lines.deliveryScheduleIncludingRequests` field **does include any open supp
 
 These additional logistics fields are only available in the order line level delivery schedule:
 
-* `lines.deliverySchedule[IncludingRequests].status`: the optional delivery line's [Logistics status](./#logistics-status).
+* `lines.deliverySchedule[IncludingRequests].status`: the optional delivery line's [Scheduled delivery logistics status](#scheduled-delivery-logistics-status).
 * `lines.deliverySchedule[IncludingRequests].etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
 * `lines.deliverySchedule[IncludingRequests].eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+
+##### Scheduled delivery logistics status
+
+The delivery line **logistics** status is one of:
+
+* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
+* `Produced`: the delivery line quantity is produced by the supplier
+* `ReadyToShip`: the delivery line quantity is ready to be shipped by the supplier
+* `Shipped`: the delivery line quantity is shipped by the supplier
+* `Delivered`: the delivery line quantity is delivered at the buyer
 
 ### Prices
 
@@ -241,6 +250,41 @@ These fields may be used in both native and simple prices:
 {% hint style="info" %}
 It is advised to only use `netPrice` for its simplicity, or alternatively use `grossPrice` together with `discountPercentage`.
 {% endhint %}
+
+### Line status
+
+#### Line process status
+
+The line **process** status is one of:
+
+* `Issued`: the line is \(re\)issued by the buyer
+* `InProgress`: the line is under negotiation between buyer and supplier
+* `Confirmed`: the line is agreed between buyer and supplier
+* `Rejected`: the line is rejected by supplier
+* `Completed`: the line is completed at the buyer
+* `Cancelled`: the line is cancelled by the buyer
+
+#### Line in Progress status
+
+The line **in progress** status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
+
+* `OpenSupplierProposal`: There is an open proposal from the supplier.
+* `RejectedSupplierProposal`: The proposal from the supplier was rejected and no other requests are open.
+* `ReissuedRejectedLine`: The rejected order line was reissued by the buyer.
+* `OpenSupplierReopenRequest`: There is an open reopen request from the supplier.
+* `OpenBuyerReopenRequest`: There is an open reopen request from the buyer.
+* `RevertedCompletedLine`: The completion of this line was reverted.
+
+#### Line logistics status
+
+The line **logistics** status is one of:
+
+* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
+* `Produced`: the line quantity is produced by the supplier
+* `ReadyToShip`: the line quantity ready to be shipped by the supplier
+* `Shipped`: the line quantity shipped by the supplier
+* `Delivered`: the line quantity delivered at the buyer
+* `Cancelled`: the line is cancelled by the buyer
 
 ### Charge lines
 

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -110,6 +110,18 @@ Order, line and delivery line **logistics** status is one of:
 
 `lines.buyerLine` is an echo of your order line fields as explained in [Issue a new order](../issue/#lines)
 
+* `requests`: the buyer can request different delivery schedule, prices and charge lines
+
+#### Buyer requests
+
+`lines.buyerLine.requests.reopenRequest`: the buyer requests to reopen the confirmed order line. The buyer has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
+
+* `deliverySchedule`: the requested alternative delivery schedule
+* `prices`: the requested alternative prices
+* `chargeLines`: the requested alternative charge lines, see [Charge lines](#charge-lines)
+* `reason`: the reason of this request given by the supplier
+* `status`: the [Request status](./#request-status).
+
 ### Supplier line
 
 `lines.supplierLine` contains the supplier order line fields:
@@ -133,21 +145,21 @@ Order, line and delivery line **logistics** status is one of:
 * `prices`: the requested alternative prices
 * `chargeLines`: the requested alternative charge lines, see [Charge lines](#charge-lines)
 * `reason`: the reason of this request given by the supplier
-* `status`: the [request status](./#request-status).
+* `status`: the [Request status](./#request-status).
 
 ##### Request status
 
 {% hint style="info" %}
 The **request** status is one of:
 
-* `Open`: Requested by the supplier. To be approved or rejected by the buyer.
-* `Approved`: The request is approved by the buyer.
-* `Rejected`: The request is approved by the supplier.
+* `Open`: Requested by one party. To be approved or rejected by the other party.
+* `Approved`: The request is approved by the other party.
+* `Rejected`: The request is rejected by the other party.
 * `Closed`: The request is closed because it is not relevant anymore.
   {% endhint %}
 
 {% hint style="warning" %}
-If the request status is `Open` the buyer must approve or reject it.
+If the request status is `Open` the other party must approve or reject it.
 {% endhint %}
 
 ### Confirmed line

--- a/order/buyer/receive/simple-order-event.md
+++ b/order/buyer/receive/simple-order-event.md
@@ -6,9 +6,13 @@ description: How to receive a simple order response sent by the supplier
 
 Tradecloud will send a purchase order response to the buyer when an order event has been triggered.
 
-## `simpleOrderEvent`
-
 This page assumes you are using the webhook with the simple delivery schedule in the `simpleOrderEvent`.
+
+When choosing polling or the native delivery schedule in the `orderEvent` please continue on:
+
+{% page-ref page="README.md" %}
+
+## `simpleOrderEvent` header
 
 * `orderId`: the Tradecloud order identifier
 * `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order)
@@ -49,7 +53,7 @@ The order status is the aggregation of all the lines statuses.
 #### Order process status
 
 {% hint style="info" %}
-The order **process** status is one of:
+The order process status is one of:
 
 * `Issued`: the order is \(re\)issued by the buyer.
 * `InProgress`: the order is under negotiation between buyer and supplier
@@ -62,7 +66,7 @@ The order **process** status is one of:
 #### Order logistics status
 
 {% hint style="info" %}
-The order **logistics** status is one of:
+The order logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the order full quantity is produced by the supplier
@@ -72,7 +76,7 @@ The order **logistics** status is one of:
 * `Cancelled`: the order is cancelled by the buyer
 {% endhint %}
 
-## Order lines
+## `simpleOrderEvent` lines
 
 `lines` contains one or more order lines:
 
@@ -136,7 +140,7 @@ These additional logistics fields are only available in the status line schedule
 ##### Scheduled delivery logistics status
 
 {% hint style="info" %}
-The delivery line **logistics** status is one of:
+The delivery line logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the delivery line quantity is produced by the supplier
@@ -173,7 +177,7 @@ It is advised to only use `netPrice` for its simplicity, or alternatively use `g
 #### Line process status
 
 {% hint style="info" %}
-The line **process** status is one of:
+The line process status is one of:
 
 * `Issued`: the line is \(re\)issued by the buyer
 * `InProgress`: the line is under negotiation between buyer and supplier
@@ -186,7 +190,7 @@ The line **process** status is one of:
 #### Line in Progress status
 
 {% hint style="info" %}
-The line **in progress** status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
+The line in progress status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
 
 * `OpenSupplierProposal`: There is an open proposal from the supplier.
 * `RejectedSupplierProposal`: The proposal from the supplier was rejected and no other requests are open.
@@ -199,7 +203,7 @@ The line **in progress** status is a more fine-grained status when an order line
 #### Line logistics status
 
 {% hint style="info" %}
-The line **logistics** status is one of:
+The line logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the line quantity is produced by the supplier

--- a/order/buyer/receive/simple-order-event.md
+++ b/order/buyer/receive/simple-order-event.md
@@ -15,8 +15,8 @@ This page assumes you are using the webhook with the simple delivery schedule in
 * `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
 * `lines`: one or more lines of the order, see [Order lines](#order-lines)
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines' [Order process statuses](#order-process-status).
-* `status.logisticsStatus`: is the aggregate of all lines' [Order logistics statuses](#order-logistics-status).
+* `status.processStatus`: is the aggregate of all lines statuses, see [Order process status](#order-process-status).
+* `status.logisticsStatus`: is the aggregate of all lines statuses, see [Order logistics status](#order-logistics-status).
 * `version`: the Tradecloud order version number
 * `eventDates`: some key order event date/times
 * `meta`: meta information, including source and trace info, about this messsage
@@ -111,7 +111,7 @@ The order **logistics** status is one of:
 
 ### Status line
 
-`lines.statusLine` represents the current order line values related to the current `Issued`, `Confirmed` or `InProgress` status. The `InclRequests` fields include the `InProgress` status and open buyer or supplier request values.
+`lines.statusLine` represents the current order line values related to the current `Issued`, `Confirmed` or `InProgress` process status. The `InclRequests` fields also include the `InProgress` status and related open buyer or supplier request values.
 
 #### Simple delivery schedule
 

--- a/order/buyer/receive/simple-order-event.md
+++ b/order/buyer/receive/simple-order-event.md
@@ -17,7 +17,6 @@ When choosing polling or the native delivery schedule in the `orderEvent` please
 * `orderId`: the Tradecloud order identifier
 * `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order)
 * `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
-* `lines`: one or more lines of the order, see [Order lines](#order-lines)
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
 * `status.processStatus`: is the aggregate of all lines statuses, see [Order process status](#order-process-status).
 * `status.logisticsStatus`: is the aggregate of all lines statuses, see [Order logistics status](#order-logistics-status).

--- a/order/buyer/receive/simple-order-event.md
+++ b/order/buyer/receive/simple-order-event.md
@@ -15,8 +15,8 @@ This page assumes you are using the webhook with the simple delivery schedule in
 * `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
 * `lines`: one or more lines of the order, see [Order lines](#order-lines)
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines' [Process statuses](#process-status).
-* `status.logisticsStatus`: is the aggregate of all lines' [Logistics statuses](#logistics-status).
+* `status.processStatus`: is the aggregate of all lines' [Order process statuses](#order-process-status).
+* `status.logisticsStatus`: is the aggregate of all lines' [Order logistics statuses](#order-logistics-status).
 * `version`: the Tradecloud order version number
 * `eventDates`: some key order event date/times
 * `meta`: meta information, including source and trace info, about this messsage
@@ -42,33 +42,29 @@ This page assumes you are using the webhook with the simple delivery schedule in
 
 {% page-ref page="download-document.md" %}
 
-### Status
+### Order status
 
-#### Process status
+#### Order process status
 
-{% hint style="info" %}
-Order and line **process** status is one of:
+The order **process** status is one of:
 
-* `Issued`: \(re\)issued by the buyer.
-* `InProgress`: under negotiation between buyer and supplier
-* `Confirmed`: agreed between buyer and supplier
-* `Rejected`: rejected by supplier
-* `Completed`: completed at the buyer
-* `Cancelled`: cancelled by the buyer
-  {% endhint %}
+* `Issued`: the order is \(re\)issued by the buyer.
+* `InProgress`: the order is under negotiation between buyer and supplier
+* `Confirmed`: the order is completely agreed between buyer and supplier
+* `Rejected`: the order is completely rejected by supplier
+* `Completed`: the order is completed at the buyer
+* `Cancelled`: the order is cancelled by the buyer
 
-#### Logistics status
+#### Order logistics status
 
-{% hint style="info" %}
-Order, line and delivery line **logistics** status is one of:
+The order **logistics** status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
-* `Produced`: full quantity produced by the supplier
-* `ReadyToShip`: full quantity ready to be shipped by the supplier
-* `Shipped`: full quantity shipped by the supplier
-* `Delivered`: full quantity delivered at the buyer
-* `Cancelled`: cancelled by the buyer
-  {% endhint %}
+* `Produced`: the order full quantity is produced by the supplier
+* `ReadyToShip`: the order full quantity is ready to be shipped by the supplier
+* `Shipped`: the order full quantity is shipped by the supplier
+* `Delivered`: the order full quantity is delivered at the buyer
+* `Cancelled`: the order is cancelled by the buyer
 
 ## Order lines
 
@@ -80,8 +76,9 @@ Order, line and delivery line **logistics** status is one of:
 * `confirmedLine`: the order line as agreed between buyer and supplier.
 * `statusLine`: the order line values representing the current `Issued`, `Confirmed` or `InProgess` status, see [Status line](#status-line).
 * `indicators.deliveryOverdue` is true when the order line is overdue.
-* `status.processStatus`: the order line's [Process status](#process-status).
-* `status.logisticsStatus`: the order line's [Logistics status](#logistics-status).
+* `status.processStatus`: the order line's [Line process status](#line-process-status).
+* `status.inProgressStatus` the order line's [Line in progress status](#line-in-progress-status).
+* `status.logisticsStatus`: the order line's [Line logistics status](#line-logistics-status).
 * `eventDates`: some key line event date/times
 * `mergedItemDetails`: detailed part information provided by both buyer and supplier, see [Item details](#item-details).
 * `lastUpdatedAt`: is the latest date time the order line has been changed.
@@ -124,9 +121,19 @@ When using `simpleOrderEvent` the simple delivery schedule is used:
 
 These additional logistics fields are only available in the status line scheduled delivery:
 
-* `lines.statusLine.scheduledDelivery[InclRequests].status`: the optional delivery line's [logistics status](#logistics-status).
+* `lines.statusLine.scheduledDelivery[InclRequests].status`: the optional delivery line's [Scheduled delivery logistics status](#scheduled-delivery-logistics-status).
 * `lines.statusLine.scheduledDelivery[InclRequests].etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
 * `lines.statusLine.scheduledDelivery[InclRequests].eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+
+##### Scheduled delivery logistics status
+
+The delivery line **logistics** status is one of:
+
+* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
+* `Produced`: the delivery line quantity is produced by the supplier
+* `ReadyToShip`: the delivery line quantity is ready to be shipped by the supplier
+* `Shipped`: the delivery line quantity is shipped by the supplier
+* `Delivered`: the delivery line quantity is delivered at the buyer
 
 #### Prices
 
@@ -150,6 +157,41 @@ These additional logistics fields are only available in the status line schedule
 {% hint style="info" %}
 It is advised to only use `netPrice` for its simplicity, or alternatively use `grossPrice` together with `discountPercentage`.
 {% endhint %}
+
+### Line status
+
+#### Line process status
+
+The line **process** status is one of:
+
+* `Issued`: the line is \(re\)issued by the buyer
+* `InProgress`: the line is under negotiation between buyer and supplier
+* `Confirmed`: the line is agreed between buyer and supplier
+* `Rejected`: the line is rejected by supplier
+* `Completed`: the line is completed at the buyer
+* `Cancelled`: the line is cancelled by the buyer
+
+#### Line in Progress status
+
+The line **in progress** status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
+
+* `OpenSupplierProposal`: There is an open proposal from the supplier.
+* `RejectedSupplierProposal`: The proposal from the supplier was rejected and no other requests are open.
+* `ReissuedRejectedLine`: The rejected order line was reissued by the buyer.
+* `OpenSupplierReopenRequest`: There is an open reopen request from the supplier.
+* `OpenBuyerReopenRequest`: There is an open reopen request from the buyer.
+* `RevertedCompletedLine`: The completion of this line was reverted.
+
+#### Line logistics status
+
+The line **logistics** status is one of:
+
+* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
+* `Produced`: the line quantity is produced by the supplier
+* `ReadyToShip`: the line quantity ready to be shipped by the supplier
+* `Shipped`: the line quantity shipped by the supplier
+* `Delivered`: the line quantity delivered at the buyer
+* `Cancelled`: the line is cancelled by the buyer
 
 ### Item details
 

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -26,8 +26,8 @@ When choosing the simple delivery schedule and using the `simpleOrderEvent` plea
 
 This page assumes you either chose the native delivery schedule using the `orderEvent` webhook API or the `order` polling API.
 
-* `id` \(in case of an Order\): the Tradecloud order identifier
-* `orderId` \(in case of an OrderEvent\): the Tradecloud order identifier
+* `id` (in case of an `order`): the Tradecloud order identifier.
+* `orderId` (in case of an `orderEvent`): the Tradecloud order identifier.
 * `buyerOrder`: the buyer part of the order, see below.
 * `supplierOrder`: the supplier part of the order.
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
@@ -35,7 +35,7 @@ This page assumes you either chose the native delivery schedule using the `order
 * `status.logisticsStatus`: is the aggregate of all lines [Order logistics statuses](#order-logistics-status).
 * `version`: the  Tradecloud order version number.
 * `eventDates`: some key order event date/times.
-* `meta`: meta information, including source and trace info, about this messsage
+* `meta`: meta information, including source and trace info, about this messsage.
 * `lastUpdatedAt`: is the latest date time the order has been changed, useful for polling orders.
 
 ### Buyer order
@@ -99,12 +99,11 @@ The order **logistics** status is one of:
 `lines` contains one or more order lines:
 
 * `id`: the Tradecloud line identifier.
-* `buyerLine`: the buyer part of the order line, see [Buyer line part](#buyer-line-part) below.
-* `supplierLine`: the supplier part of the order line, see [Supplier line part](#supplier-line-part) below.
+* `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line) below.
+* `supplierLine`: the supplier part of the order line, see [Supplier line](#supplier-line) below.
 * `confirmedLine`: the order line as agreed between buyer and supplier, see [Confirmed line](#confirmed-line) below.
-* `deliverySchedule`: the current aggregated delivery schedule, see [Current delivery schedule](#current-delivery-schedule).
-* `deliveryScheduleIncludingRequests`: the current aggregated delivery schedule including requests, see [Current delivery schedule](#current-delivery-schedule).
-* `scheduledDelivery`: the current aggregated delivery line, see [Current scheduled delivery](#current-delivery-line).
+* `deliverySchedule`: the current aggregated delivery schedule, see [Native delivery schedule](#native-delivery-schedule).
+* `deliveryScheduleIncludingRequests`: the current aggregated delivery schedule including requests, see [Native delivery schedule](#native-delivery-schedule).
 * `prices`: the actual prices, see [Prices](#prices) below.
 * `pricesIncludingRequests`: the actual prices, including any open supplier or buyer requests, see [Prices](#prices).
 * `indicators.deliveryOverdue` is true when the order line is overdue.
@@ -305,9 +304,9 @@ The line **logistics** status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the line quantity is produced by the supplier
-* `ReadyToShip`: the line quantity ready to be shipped by the supplier
-* `Shipped`: the line quantity shipped by the supplier
-* `Delivered`: the line quantity delivered at the buyer
+* `ReadyToShip`: the line quantity is ready to be shipped by the supplier
+* `Shipped`: the line quantity is shipped by the supplier
+* `Delivered`: the line quantity is delivered at the buyer
 * `Cancelled`: the line is cancelled by the buyer
 {% endhint %}
 

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -18,11 +18,11 @@ If you choose the POST webhook API, you may choose between the native or simple 
 
 {% page-ref page="../../../api/delivery-schedule.md" %}
 
-When choosing the simple delivery schedule and using the `simpleOrderEvent` please continue on:
+When choosing the simple delivery schedule with the `simpleOrderEvent` please continue on:
 
 {% page-ref page="simple-order-event.md" %}
 
-## `orderEvent` or `order`
+## `orderEvent` or `order` header
 
 This page assumes you either chose the native delivery schedule using the `orderEvent` webhook API or the `order` polling API.
 
@@ -71,7 +71,7 @@ The order status is the aggregation of all the lines statuses.
 #### Order process status
 
 {% hint style="info" %}
-The order **process** status is one of:
+The order process status is one of:
 
 * `Issued`: the order is \(re\)issued by the buyer.
 * `InProgress`: the order is under negotiation between buyer and supplier
@@ -84,7 +84,7 @@ The order **process** status is one of:
 #### Order logistics status
 
 {% hint style="info" %}
-The order **logistics** status is one of:
+The order logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the order full quantity is produced by the supplier
@@ -94,7 +94,7 @@ The order **logistics** status is one of:
 * `Cancelled`: the order is cancelled by the buyer
 {% endhint %}
 
-## Order lines
+## `orderEvent` or `order` lines
 
 `lines` contains one or more order lines:
 
@@ -160,7 +160,7 @@ The order **logistics** status is one of:
 ##### Request status
 
 {% hint style="info" %}
-The **request** status is one of:
+The request status is one of:
 
 * `Open`: Requested by one party. To be approved or rejected by the other party.
 * `Approved`: The request is approved by the other party.
@@ -225,7 +225,7 @@ These additional logistics fields are only available in the order line level del
 ##### Scheduled delivery logistics status
 
 {% hint style="info" %}
-The delivery line **logistics** status is one of:
+The delivery line logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the delivery line quantity is produced by the supplier
@@ -273,7 +273,7 @@ It is advised to only use `netPrice` for its simplicity, or alternatively use `g
 #### Line process status
 
 {% hint style="info" %}
-The line **process** status is one of:
+The line process status is one of:
 
 * `Issued`: the line is \(re\)issued by the buyer
 * `InProgress`: the line is under negotiation between buyer and supplier
@@ -287,7 +287,7 @@ The line **process** status is one of:
 #### Line in Progress status
 
 {% hint style="info" %}
-The line **in progress** status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
+The line in progress status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
 
 * `OpenSupplierProposal`: There is an open proposal from the supplier.
 * `RejectedSupplierProposal`: The proposal from the supplier was rejected and no other requests are open.
@@ -300,7 +300,7 @@ The line **in progress** status is a more fine-grained status when an order line
 #### Line logistics status
 
 {% hint style="info" %}
-The line **logistics** status is one of:
+The line logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the line quantity is produced by the supplier

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -134,7 +134,7 @@ Order, line and delivery line **logistics** status is one of:
 
 ### Item
 
-`item`: the item \(or article, goods\) to be delivered
+* `item`: the item \(or article, goods\) to be delivered
 * `number`: the item code or number as known in the buyer ERP system.
 * `revision`: the revision \(or version\) of this item number
 * `name`: the item short name
@@ -173,17 +173,17 @@ The `deliverySchedule` field does **NOT** include any open supplier or buyer req
 The `deliveryScheduleIncludingRequests` field **does** include any open supplier or buyer request. Be aware that either the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
 {% endhint %}
 
-  * `position`: the optional position in the delivery schedule. Not to be confused with the `line.position`
-  * `date`: the delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-  * `quantity`: the quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
+* `position`: the optional position in the delivery schedule. Not to be confused with the `line.position`
+* `date`: the delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
+* `quantity`: the quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
 
 ### Logistics fields
 
 These additional logistics fields are only available in the order line level delivery schedule:
 
-  * `status`: the optional delivery line's [logistics status](./#logistics-status).
-  * `etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-  * `eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+* `status`: the optional delivery line's [logistics status](./#logistics-status).
+* `etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+* `eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
 
 ## Simple Delivery schedule
 
@@ -193,47 +193,50 @@ These additional logistics fields are only available in the order line level del
 The `scheduledDelivery` field **does** include any open supplier or buyer request. Be aware that either the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
 {% endhint %}
 
-  * `date`: the delivery date of this delivery line. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-  * `quantity`: the quantity of this delivery line. Quantity has a decimal `1234.56` format with any number of digits.
+* `date`: the delivery date of this delivery line. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
+* `quantity`: the quantity of this delivery line. Quantity has a decimal `1234.56` format with any number of digits.
 
 ### Logistics fields
 
-  * `status`: the optional delivery line's [logistics status](./#logistics-status).
-  * `etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-  * `eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+* `status`: the optional delivery line's [logistics status](./#logistics-status).
+* `etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+* `eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
 
 ### Requested prices
 
-`lines.prices`: the requested price. Buyers are advised to provide only `netPrice` for its simplicity, or alternatively `grossPrice` together with `discountPercentage`. 
+`lines.prices`: the requested price. Buyers are advised to provide only `netPrice` for its simplicity, or alternatively `grossPrice` together with `discountPercentage`.
+
 * `grossPrice`: the gross price. Used together with `discountPercentage`.
 * `discountPercentage`: the discount percentage. Used together with `grossPrice`.
 * `netPrice`: the net price.
-    * `priceInTransactionCurrency`: the price in the transaction currency, like `CNY` in China.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
-    * `priceInBaseCurrency`: optional price in the buyer's base currency, like `EUR` in the EU.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
+  * `priceInTransactionCurrency`: the price in the transaction currency, like `CNY` in China.
+    * `value`: the price value has a decimal `1234.56` format with any number of digits.
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
+  * `priceInBaseCurrency`: optional price in the buyer's base currency, like `EUR` in the EU.
+    * `value`: the price value has a decimal `1234.56` format with any number of digits.
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
 * `priceUnitOfMeasureIso`: the price unit according to ISO 80000-1. The purchase unit and price unit may be different.
 * `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
 
 ### Requested charge lines
 
 `lines.chargeLines`: the requested additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
+
 * `position`: the position used to identify a charge line.
 * `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
 * `chargeDescription`: a mandatory free text description, like "Transport costs".
 * `quantity`: the mandatory quantity of this charge line.
 * `price`: the mandatory price of this charge line.
-    * `priceInTransactionCurrency`: the mandatory price in the transaction currency of the supplier, like `CNY` in China.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
-    * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
+  * `priceInTransactionCurrency`: the mandatory price in the transaction currency of the supplier, like `CNY` in China.
+    * `value`: the price value has a decimal `1234.56` format with any number of digits.
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
+  * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
 * `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1 which applies to the charge line price.
 
 ### Buyer requests
 
 `requests.reopenRequest`: the buyer requests to reopen the confirmed order line. The buyer has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
+
 * `deliverySchedule`: requested alternative delivery schedule, see below
 * `prices`: requested alternative prices, see below
 * `chargeLines`: requested alternative charge lines, see below
@@ -245,22 +248,22 @@ The `scheduledDelivery` field **does** include any open supplier or buyer reques
 {% hint style="info" %}
 The **request** status is one of:
 
-* `Open`: Requested by the buyer. To be approved or rejected by the supplier.
-* `Approved`: The request is approved by the supplier.
-* `Rejected`:  The request is approved by the supplier.
+* `Open`: Requested by one party. To be approved or rejected by the other party.
+* `Approved`: The request is approved by the other party.
+* `Rejected`:  The request is approved by the other party.
 * `Closed`: The request is closed because it is not relevant anymore.
 {% endhint %}
 
 {% hint style="warning" %}
-If the request status is `Open` the supplier must approve or reject it.
+If the request status is `Open` the other party must approve or reject it.
 {% endhint %}
 
 #### Other buyer line fields
 
 * `description`: a free format additional description of this line
 * `terms`: the line terms as agreed with your buyer
-    * `contractNumber`: the agreed framework contract number
-    * `contractPosition`: the related position within the framework contract
+  * `contractNumber`: the agreed framework contract number
+  * `contractPosition`: the related position within the framework contract
 * `projectNumber`: The buyer's project number reference
 * `productionNumber`:  The buyer's production number reference
 * `salesOrderNumber`:  The buyer's sales order number \(not be confused with your sales order number\)
@@ -273,12 +276,24 @@ If the request status is `Open` the supplier must approve or reject it.
 
 {% page-ref page="download-document.md" %}
 
-### Supplier line part
+### Supplier line
 
 `supplierLine` is mostly an echo of your order line fields as explained in [Send order response](../send-order-response/)​.
 
 * `salesOrderNumber`: the sales order number as known in your ERP system
 * `salesOrderPosition`: the position within the sales order
+* `requests`: the supplier can request different delivery schedule, prices and charge lines:
+
+### Supplier requests
+
+`lines.supplierLine.requests.proposal`: the supplier has proposed a different delivery schedule, prices and/or charge lines compared to the issued order line.
+`lines.supplierLine.requests.reopenRequest`: the supplier requests to reopen the confirmed order line. The supplier has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
+
+* `deliverySchedule`: requested alternative delivery schedule, see below
+* `prices`: requested alternative prices, see below
+* `chargeLines`: requested alternative charge lines, see below
+* `reason`: the reason of this request given by the buyer
+* `status`: the [request status](./#request-status).
 
 ## Confirmed line
 
@@ -307,6 +322,7 @@ Only if the [process status](./#process-status) is `Confirmed`, the line is agre
 These additional logistics fields are only available in the order line level delivery schedule:
 
 `deliverySchedule`: the requested or confirmed delivery schedule.
+
 * `status`: the optional delivery line [logistics status](./#logistics-status).
 * `etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
 * `eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
@@ -320,14 +336,14 @@ These additional logistics fields are only available in the order line level del
 * `grossPrice`: the gross price. Used together with `discountPercentage`.
 * `discountPercentage`: the discount percentage. Used together with `grossPrice`.
 * `netPrice`: the net price.
-    * `priceInTransactionCurrency`: the  price in the transaction currency, like `CNY` in China.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
-    * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.    
-    * `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-    * `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
+  * `priceInTransactionCurrency`: the  price in the transaction currency, like `CNY` in China.
+    * `value`: the price value has a decimal `1234.56` format with any number of digits.
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
+  * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
+    * `value`: the price value has a decimal `1234.56` format with any number of digits.
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.    
+* `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.
+* `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
 
 {% hint style="info" %}
 It is advised to only use `netPrice` for its simplicity, or alternatively use `grossPrice` together with `discountPercentage`.
@@ -336,15 +352,16 @@ It is advised to only use `netPrice` for its simplicity, or alternatively use `g
 ## Charge lines
 
 `chargeLines`: the requested or confirmed additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
+
 * `position`: the position used to identify a charge line.
 * `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
 * `chargeDescription`: a mandatory free text description, like "Transport costs".
 * `quantity`: the mandatory quantity of this charge line.
 * `price`: the mandatory price of this charge line.
-    * `priceInTransactionCurrency`: the mandatory price in the transaction currency of the supplier, like `CNY` in China.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
-    * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.  
+  * `priceInTransactionCurrency`: the mandatory price in the transaction currency of the supplier, like `CNY` in China.
+    * `value`: the price value has a decimal `1234.56` format with any number of digits.
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
+  * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
+    * `value`: the price value has a decimal `1234.56` format with any number of digits.
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.  
 * `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1 which applies to the charge line price.

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -4,7 +4,7 @@ description: How to receive a purchase order sent by the buyer.
 
 # Receive an order
 
-Tradecloud will send a new purchase order to the supplier when an order event has been triggered.
+Tradecloud will send a purchase order, either new or updated, to the supplier when an order event has been triggered.
 
 ## Choose the appropriate API to receive an order
 
@@ -12,27 +12,33 @@ First choose either the webhook API or the polling API to receive order messages
 
 {% page-ref page="../../../api/webhook-vs-polling.md" %}
 
-## Choose to receive the native or simple delivery schedule 
+## Choose to receive the native or simple delivery schedule
 
 If you choose the POST webhook API, you may choose between the native or simple delivery schedule:
 
 {% page-ref page="../../../api/delivery-schedule.md" %}
 
-## Order or OrderEvent
+When choosing the simple delivery schedule and using the `simpleOrderEvent` please continue on:
+
+{% page-ref page="simple-order-event.md" %}
+
+## `orderEvent` or `order`
+
+This page assumes you either chose the native delivery schedule using the `orderEvent` webhook API or the `order` polling API.
 
 * `id` \(in case of an Order\): the Tradecloud order identifier
 * `orderId` \(in case of an OrderEvent\): the Tradecloud order identifier
 * `buyerOrder`: the buyer part of the order, see below.
 * `supplierOrder`: the supplier part of the order.
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines [process status](./#process-status).
-* `status.logisticsStatus`: is the aggregate of all lines [logistics status](./#logistics-status).
+* `status.processStatus`: is the aggregate of all lines [Order process statuses](#order-process-status).
+* `status.logisticsStatus`: is the aggregate of all lines [Order logistics statuses](#order-logistics-status).
 * `version`: the  Tradecloud order version number.
 * `eventDates`: some key order event date/times.
 * `meta`: meta information, including source and trace info, about this messsage
 * `lastUpdatedAt`: is the latest date time the order has been changed, useful for polling orders.
 
-### Buyer order part
+### Buyer order
 
 `buyerOrder` contains the buyer order fields:
 
@@ -48,7 +54,7 @@ If you choose the POST webhook API, you may choose between the native or simple 
 
 {% page-ref page="download-document.md" %}
 
-### Supplier order part
+### Supplier order
 
 `supplierOrder` is mostly an echo of your order fields as explained in [Send order response](../send-order-response/)​.
 
@@ -56,6 +62,36 @@ If you choose the POST webhook API, you may choose between the native or simple 
 
 {% hint style="warning" %}
 The `buyerAccountNumber` should be set on forehand in the Tradecloud connection with your buyer. You can set the account code when inviting a new connection or in the connection overview in the portal.
+{% endhint %}
+
+### Order status
+
+The order status is the aggregation of all the lines statuses.
+
+#### Order process status
+
+{% hint style="info" %}
+The order **process** status is one of:
+
+* `Issued`: the order is \(re\)issued by the buyer.
+* `InProgress`: the order is under negotiation between buyer and supplier
+* `Confirmed`: the order is completely agreed between buyer and supplier
+* `Rejected`: the order is completely rejected by supplier
+* `Completed`: the order is completed at the buyer
+* `Cancelled`: the order is cancelled by the buyer
+{% endhint %}
+
+#### Order logistics status
+
+{% hint style="info" %}
+The order **logistics** status is one of:
+
+* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
+* `Produced`: the order full quantity is produced by the supplier
+* `ReadyToShip`: the order full quantity is ready to be shipped by the supplier
+* `Shipped`: the order full quantity is shipped by the supplier
+* `Delivered`: the order full quantity is delivered at the buyer
+* `Cancelled`: the order is cancelled by the buyer
 {% endhint %}
 
 ## Order lines
@@ -72,195 +108,21 @@ The `buyerAccountNumber` should be set on forehand in the Tradecloud connection 
 * `prices`: the actual prices, see [Prices](#prices) below.
 * `pricesIncludingRequests`: the actual prices, including any open supplier or buyer requests, see [Prices](#prices).
 * `indicators.deliveryOverdue` is true when the order line is overdue.
-* `status.processStatus`: the order line's [Process status](#process-status).
-* `status.logisticsStatus`: the order line's [Logistics status](#logistics-status).
+* `status.processStatus`: the order line's [Line process status](#line-process-status).
+* `status.inProgressStatus` the order line's [Line in progress status](#line-in-progress-status).
+* `status.logisticsStatus`: the order line's [Line logistics status](#line-logistics-status).
 * `eventDates`: some key line event date/times.
 * `mergedItemDetails`: detailed part information provided by both buyer and supplier, see [Item details](#item-details).
 * `lastUpdatedAt`: is the latest date time the order line has been changed, useful for polling.
 
-### Current delivery schedule
-
-* `deliverySchedule`: the current aggregated delivery schedule with logistics info, see [Native Delivery Schedule](#native-delivery-schedule) below.
-* `deliveryScheduleIncludingRequests`: the current aggregated delivery schedule including any open supplier or buyer requests, see [Native Delivery Schedule](#native-delivery-schedule) below.
-
-{% hint style="info" %}
-It is **strongly advised** to use the `lines.deliverySchedule` together with the `lines.prices` fields, which are **the current delivery schedule and prices**. It gives a simpler alternative for the `deliverySchedule` and `prices` fields in different places like `buyerLine`, `buyerLine.requests`, `supplierLine.requests` and `confirmedLine`.
-
-The `lines.deliveryScheduleIncludingRequests` together with `lines.pricesIncludingRequests` fields **include any open supplier or buyer request**. You can use the `IncludingRequests` fields when you need the `deliverySchedule` and `prices` fields in the proposal or reopen requests as soon as possible, before approving, in your ERP.
-
-The `deliveryScheduleIncludingRequests`, `prices` and `pricesIncludingRequests` fields are only available in the new webhook, using the "Orders Webhook Integration" configuration in your company settings page, and are also available in the `order-search` API when using polling.
-{% endhint %}
-
-### Current delivery line
-
-* `scheduledDelivery`: the current aggregated delivery line with logistics info, see [Simple Delivery Schedule](#simple-delivery-schedule) below.
-
-{% hint style="warning" %}
-The `scheduledDelivery` field includes any open supplier or buyer request, there is no separate `scheduledDeliveryIncludingRequests` variant available.
-{% endhint %}
-
-### Status
-
-#### Process status
-
-{% hint style="info" %}
-Order and line **process** status is one of:
-
-* `Issued`: \(re\)issued by the buyer.
-* `InProgress`: under negotiation between buyer and supplier
-* `Confirmed`: agreed between buyer and supplier
-* `Rejected`: rejected by supplier
-* `Completed`: completed at the buyer
-* `Cancelled`: cancelled by either buyer or supplier
-{% endhint %}
-
-#### Logistics status
-
-{% hint style="info" %}
-Order, line and delivery line **logistics** status is one of:
-
-* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
-* `Produced`: full quantity produced by the supplier
-* `ReadyToShip`: full quantity ready to be shipped by the supplier
-* `Shipped`: full quantity shipped by the supplier
-* `Delivered`: full quantity delivered at the buyer
-{% endhint %}
-
-### Buyer line part
+### Buyer line
 
 `buyerLine` contains the buyer order line fields:
 
 * `position`: the line position within the purchase order
-
-### Item
-
-* `item`: the item \(or article, goods\) to be delivered
-* `number`: the item code or number as known in the buyer ERP system.
-* `revision`: the revision \(or version\) of this item number
-* `name`: the item short name
-* `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`
-* `supplierItemNumber`: the item code or number as known at the supplier. 
-
-### Item details
-
-`lines.itemDetails`: detailed part information initially provided by buyer.
-
-{% hint style="info" %}
-The buyer may send item details to inform the supplier about part information.  
-The supplier may check, change and add item details if they are not correct or incomplete.  
-The `mergedItemDetails` will contain the original item details added by the buyer merged with the changed or added item details by the supplier.
-{% endhint %}
-
-* `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture, production, or growth where an article or product comes from.
-* `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the requirements both of the Common Customs Tariff and of the EU's external trade statistics.
-* `netWeight`: Net weight of one item.
-* `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
-* `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that identify dangerous goods, hazardous substances and articles in the framework of international transport.
-* `serialNumber`: is an unique identifier assigned incrementally or sequentially to an item, to uniquely identify it.
-* `batchNumber`: is an identification number assigned to a particular quantity or lot of material from a single manufacturer
-
-## Native Delivery schedule
-
-`lines.deliverySchedule`: the current delivery schedule, either `Issued` or `Confirmed`.
-
-{% hint style="warning" %}
-The `deliverySchedule` field does **NOT** include any open supplier or buyer request. Be aware that the `Issued` or `Confirmed` values are returned, dependent on the line status.
-{% endhint %}
-
-`lines.deliveryScheduleIncludingRequests`: the current delivery schedule, including any open supplier or buyer request, either `Issued`, `In Progress` or `Confirmed` values.
-
-{% hint style="warning" %}
-The `deliveryScheduleIncludingRequests` field **does** include any open supplier or buyer request. Be aware that either the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
-{% endhint %}
-
-* `position`: the optional position in the delivery schedule. Not to be confused with the `line.position`
-* `date`: the delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-* `quantity`: the quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
-
-### Logistics fields
-
-These additional logistics fields are only available in the order line level delivery schedule:
-
-* `status`: the optional delivery line's [logistics status](./#logistics-status).
-* `etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-* `eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-
-## Simple Delivery schedule
-
-`lines.scheduledDelivery`: the current delivery line, including open proposal or reopen requests, when using the simple delivery schedule.
-
-{% hint style="warning" %}
-The `scheduledDelivery` field **does** include any open supplier or buyer request. Be aware that either the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
-{% endhint %}
-
-* `date`: the delivery date of this delivery line. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-* `quantity`: the quantity of this delivery line. Quantity has a decimal `1234.56` format with any number of digits.
-
-### Logistics fields
-
-* `status`: the optional delivery line's [logistics status](./#logistics-status).
-* `etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-* `eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-
-### Requested prices
-
-`lines.prices`: the requested price. Buyers are advised to provide only `netPrice` for its simplicity, or alternatively `grossPrice` together with `discountPercentage`.
-
-* `grossPrice`: the gross price. Used together with `discountPercentage`.
-* `discountPercentage`: the discount percentage. Used together with `grossPrice`.
-* `netPrice`: the net price.
-  * `priceInTransactionCurrency`: the price in the transaction currency, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
-  * `priceInBaseCurrency`: optional price in the buyer's base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `priceUnitOfMeasureIso`: the price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-* `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
-
-### Requested charge lines
-
-`lines.chargeLines`: the requested additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
-
-* `position`: the position used to identify a charge line.
-* `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
-* `chargeDescription`: a mandatory free text description, like "Transport costs".
-* `quantity`: the mandatory quantity of this charge line.
-* `price`: the mandatory price of this charge line.
-  * `priceInTransactionCurrency`: the mandatory price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
-  * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
-* `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1 which applies to the charge line price.
-
-### Buyer requests
-
-`requests.reopenRequest`: the buyer requests to reopen the confirmed order line. The buyer has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
-
-* `deliverySchedule`: requested alternative delivery schedule, see below
-* `prices`: requested alternative prices, see below
-* `chargeLines`: requested alternative charge lines, see below
-* `reason`: the reason of this request given by the buyer
-* `status`: the [request status](./#request-status).
-
-#### Request status
-
-{% hint style="info" %}
-The **request** status is one of:
-
-* `Open`: Requested by one party. To be approved or rejected by the other party.
-* `Approved`: The request is approved by the other party.
-* `Rejected`:  The request is approved by the other party.
-* `Closed`: The request is closed because it is not relevant anymore.
-{% endhint %}
-
-{% hint style="warning" %}
-If the request status is `Open` the other party must approve or reject it.
-{% endhint %}
-
-#### Other buyer line fields
-
 * `description`: a free format additional description of this line
+* `item`: the item (or article, goods) to be delivered, see [Item](#item)
+* `requests`: the buyer can request different delivery schedule, prices and charge lines
 * `terms`: the line terms as agreed with your buyer
   * `contractNumber`: the agreed framework contract number
   * `contractPosition`: the related position within the framework contract
@@ -276,80 +138,180 @@ If the request status is `Open` the other party must approve or reject it.
 
 {% page-ref page="download-document.md" %}
 
-### Supplier line
+#### Item
 
-`supplierLine` is mostly an echo of your order line fields as explained in [Send order response](../send-order-response/)​.
+`lines.buyerLine.item`: The item (or article, goods) to be delivered.
 
-* `salesOrderNumber`: the sales order number as known in your ERP system
-* `salesOrderPosition`: the position within the sales order
-* `requests`: the supplier can request different delivery schedule, prices and charge lines:
+* `number`: the item code or number as known in the buyer ERP system.
+* `revision`: the revision (or version) of this item number
+* `name`: the item short name
+* `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`
+* `supplierItemNumber`: the item code or number as known at the supplier.
 
-### Supplier requests
+#### Buyer requests
 
-`lines.supplierLine.requests.proposal`: the supplier has proposed a different delivery schedule, prices and/or charge lines compared to the issued order line.
-`lines.supplierLine.requests.reopenRequest`: the supplier requests to reopen the confirmed order line. The supplier has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
+`lines.buyerLine.requests.reopenRequest`: the buyer requests to reopen the confirmed order line. The buyer has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
 
-* `deliverySchedule`: requested alternative delivery schedule, see below
-* `prices`: requested alternative prices, see below
-* `chargeLines`: requested alternative charge lines, see below
-* `reason`: the reason of this request given by the buyer
-* `status`: the [request status](./#request-status).
+* `deliverySchedule`: the requested alternative delivery schedule
+* `prices`: the requested alternative prices
+* `chargeLines`: the requested alternative charge lines, see [Charge lines](#charge-lines)
+* `reason`: the reason of this request given by the supplier
+* `status`: the [Request status](#request-status).
 
-## Confirmed line
+##### Request status
 
-`confirmedLine`: the agreed order line between buyer and supplier.
+{% hint style="info" %}
+The **request** status is one of:
 
-{% hint style="warning" %}
-Only if the [process status](./#process-status) is `Confirmed`, the line is agreed between buyer and supplier.
+* `Open`: Requested by one party. To be approved or rejected by the other party.
+* `Approved`: The request is approved by the other party.
+* `Rejected`: The request is rejected by the other party.
+* `Closed`: The request is closed because it is not relevant anymore.
 {% endhint %}
 
-* `deliverySchedule`: agreed delivery schedule, see below
-* `prices`: agreed prices, see below
-* `chargeLines`: agreed charge lines, see below
+{% hint style="warning" %}
+If the request status is `Open` the other party must approve or reject it.
+{% endhint %}
 
-## Delivery schedule
+### Supplier line
 
-`deliverySchedule`: the actual delivery schedule, either `Issued` or `Confirmed`.
+`supplierLine` is an echo of your order line fields as explained in [Send order response](../send-order-response/)​.
 
-`deliveryScheduleIncludingRequests`: the actual delivery schedule, either `Issued`, `In Progress` (having an open `Proposal` or `Reopen Request`) or `Confirmed`.
+### Confirmed line
 
-* `position`: the optional position in the delivery schedule. Not to be confused with the `line.position`
-* `date`: the delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-* `quantity`: the quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
+`lines.confirmedLine`: the agreed order line between buyer and supplier.
 
-### Logistics fields
+{% hint style="warning" %}
+Only if the process status is `Confirmed` the line is agreed between buyer and supplier
+{% endhint %}
+
+* `lines.confirmedLine.deliverySchedule`: the agreed delivery schedule
+* `lines.confirmedLine.prices`: the agreed prices
+* `lines.confirmedLine.chargeLines`: the agreed charge lines, see [Charge lines](#charge-lines)
+
+### Native delivery schedule
+
+When using `order` or `orderEvent` the native delivery schedule is used.
+
+{% hint style="info" %}
+The `lines.deliverySchedule` together with the `lines.prices` fields give a simpler alternative for the `deliverySchedule` and `prices` fields in different places like `buyerLine`, `buyerLine.requests`, `supplierLine.requests` and `confirmedLine`.
+{% endhint %}
+
+* `lines.deliverySchedule`: the current delivery schedule, either having `Issued` or `Confirmed` values.
+
+{% hint style="warning" %}
+The `lines.deliverySchedule` field does **NOT include any open supplier or buyer request**. Be aware that either the `Issued` or `Confirmed` values are returned, dependent on the line status.
+{% endhint %}
+
+* `lines.deliveryScheduleIncludingRequests`: the current delivery schedule, either having `Issued`, `In Progress` or `Confirmed` values.
+
+{% hint style="warning" %}
+The `lines.deliveryScheduleIncludingRequests` field **does include any open supplier or buyer request**. Be aware that the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
+{% endhint %}
+
+#### Delivery schedule fields
+
+* `lines.deliverySchedule[IncludingRequests].position`: the optional position in the delivery schedule. Not to be confused with the `line.position`
+* `lines.deliverySchedule[IncludingRequests].date`: the delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
+* `lines.deliverySchedule[IncludingRequests].quantity`: the quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
+
+##### Logistics fields
 
 These additional logistics fields are only available in the order line level delivery schedule:
 
-`deliverySchedule`: the requested or confirmed delivery schedule.
+* `lines.deliverySchedule[IncludingRequests].status`: the optional delivery line's [Scheduled delivery logistics status](#scheduled-delivery-logistics-status).
+* `lines.deliverySchedule[IncludingRequests].etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+* `lines.deliverySchedule[IncludingRequests].eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
 
-* `status`: the optional delivery line [logistics status](./#logistics-status).
-* `etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-* `eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+##### Scheduled delivery logistics status
 
-## Prices
+{% hint style="info" %}
+The delivery line **logistics** status is one of:
 
-`prices`: the actual prices, either `Issued` or `Confirmed`. 
+* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
+* `Produced`: the delivery line quantity is produced by the supplier
+* `ReadyToShip`: the delivery line quantity is ready to be shipped by the supplier
+* `Shipped`: the delivery line quantity is shipped by the supplier
+* `Delivered`: the delivery line quantity is delivered at the buyer
+{% endhint %}
 
-`pricesIncludingRequests`: the actual prices, either `Issued`, `In Progress` (having an open `Proposal` or `Reopen Request`) or `Confirmed`.
+### Prices
 
-* `grossPrice`: the gross price. Used together with `discountPercentage`.
-* `discountPercentage`: the discount percentage. Used together with `grossPrice`.
-* `netPrice`: the net price.
-  * `priceInTransactionCurrency`: the  price in the transaction currency, like `CNY` in China.
+* `lines.prices`: the current prices, either having `Issued` or `Confirmed` values.
+
+{% hint style="warning" %}
+The `lines.prices` field does **NOT include any open supplier or buyer request**. Be aware that either the `Issued` or `Confirmed` values are returned, dependent on the line status.
+{% endhint %}
+
+* `lines.pricesIncludingRequests`: the current prices, either having `Issued`, `In Progress` or `Confirmed` values.
+
+{% hint style="warning" %}
+The `lines.pricesIncludingRequests` field **includes any open supplier or buyer request**. Be aware that the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
+{% endhint %}
+
+#### Prices fields
+
+These fields may be used in both native and simple prices:
+
+* `lines.prices[IncludingRequests].grossPrice`: the gross price. Used together with `discountPercentage`.
+* `lines.prices[IncludingRequests].discountPercentage`: the discount percentage. Used together with `grossPrice`.
+* `lines.prices[IncludingRequests].netPrice`: the net price.
+  * `priceInTransactionCurrency`: the price in the transaction currency of the supplier, like `CNY` in China.
     * `value`: the price value has a decimal `1234.56` format with any number of digits.
     * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
-  * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
+  * `priceInBaseCurrency`: the price in your base currency, like `EUR` in the EU.
     * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.    
-* `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-* `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
+* `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.
+* `lines.prices[IncludingRequests].priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
 
 {% hint style="info" %}
 It is advised to only use `netPrice` for its simplicity, or alternatively use `grossPrice` together with `discountPercentage`.
 {% endhint %}
 
-## Charge lines
+### Line status
+
+#### Line process status
+
+{% hint style="info" %}
+The line **process** status is one of:
+
+* `Issued`: the line is \(re\)issued by the buyer
+* `InProgress`: the line is under negotiation between buyer and supplier
+* `Confirmed`: the line is agreed between buyer and supplier
+* `Rejected`: the line is rejected by supplier
+* `Completed`: the line is completed at the buyer
+* `Cancelled`: the line is cancelled by the buyer
+
+{% endhint %}
+
+#### Line in Progress status
+
+{% hint style="info" %}
+The line **in progress** status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
+
+* `OpenSupplierProposal`: There is an open proposal from the supplier.
+* `RejectedSupplierProposal`: The proposal from the supplier was rejected and no other requests are open.
+* `ReissuedRejectedLine`: The rejected order line was reissued by the buyer.
+* `OpenSupplierReopenRequest`: There is an open reopen request from the supplier.
+* `OpenBuyerReopenRequest`: There is an open reopen request from the buyer.
+* `RevertedCompletedLine`: The completion of this line was reverted.
+{% endhint %}
+
+#### Line logistics status
+
+{% hint style="info" %}
+The line **logistics** status is one of:
+
+* `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
+* `Produced`: the line quantity is produced by the supplier
+* `ReadyToShip`: the line quantity ready to be shipped by the supplier
+* `Shipped`: the line quantity shipped by the supplier
+* `Delivered`: the line quantity delivered at the buyer
+* `Cancelled`: the line is cancelled by the buyer
+{% endhint %}
+
+### Charge lines
 
 `chargeLines`: the requested or confirmed additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
 
@@ -363,5 +325,21 @@ It is advised to only use `netPrice` for its simplicity, or alternatively use `g
     * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
   * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
     * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.  
+    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
 * `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1 which applies to the charge line price.
+
+### Item details
+
+{% hint style="info" %}
+The buyer may send item details to inform the supplier about part information.  
+The supplier may check, change and add item details if they are not correct or incomplete.  
+`lines.mergedItemDetails` will contain the original item details added by the buyer merged with the changed or added item details by the supplier.
+{% endhint %}
+
+* `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture, production, or growth where an article or product comes from.
+* `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the requirements both of the Common Customs Tariff and of the EU's external trade statistics.
+* `netWeight`: Net weight of one item.
+* `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+* `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that identify dangerous goods, hazardous substances and articles in the framework of international transport.
+* `serialNumber`: is an unique identifier assigned incrementally or sequentially to an item, to uniquely identify it.
+* `batchNumber`: is an identification number assigned to a particular quantity or lot of material from a single manufacturer

--- a/order/supplier/receive/simple-order-event.md
+++ b/order/supplier/receive/simple-order-event.md
@@ -1,10 +1,10 @@
 ---
-description: How to receive a simple order response sent by the supplier
+description: How to receive a simple order sent by the buyer.
 ---
 
-# Receive an order response
+# Receive an order
 
-Tradecloud will send a purchase order response to the buyer when an order event has been triggered.
+Tradecloud will send a purchase order, either new or updated, to the supplier when an order event has been triggered.
 
 ## `simpleOrderEvent`
 
@@ -24,23 +24,29 @@ This page assumes you are using the webhook with the simple delivery schedule in
 
 ### Buyer order
 
-`buyerOrder` is mostly an echo of your order fields as explained in [Issue a new order](../issue/#order-body-json-objects)
+`buyerOrder` contains the buyer order fields:
 
-* `supplierAccountNumber`: the supplier account number as known in your ERP system
+* `companyId`: the buyer's Tradecloud company identifier.
+* `supplierAccountNumber`: your account number as known in the buyer's ERP system.
+* `description`: a free format additional description of this order added by the buyer.
+* `contact`: the buyer employee responsible for this order.
+* `properties`: are key-value based custom fields, added by the buyer.
+* `notes`: are simple custom fields, added by the buyer.
+* `labels`: value-added services labels on order level.
+* `documents`: contain meta data, objectId or url, of attached documents by the buyer, see:
+* `orderType`: the order type, one of `Purchase` or `Forecast`.
+
+{% page-ref page="download-document.md" %}
 
 ### Supplier order
 
-`supplierOrder` contains the supplier order fields:
+`supplierOrder` is mostly an echo of your order fields as explained in [Send order response](../send-order-response/)​.
 
-* `companyId`: the supplier's Tradecloud company identifier.
-* `buyerAccountNumber`: your account number as known in the supplier's ERP system.
-* `description`: a free format additional description of this order by the supplier.
-* `contact`: the supplier employee responsible for this order.
-* `properties`: are key-value based custom fields, added by the supplier.
-* `notes`: are simple custom fields, added by the supplier.
-* `documents`: contain meta data and link of attached documents by the supplier.
+* `buyerAccountNumber`: the buyer account number as known in your ERP system.
 
-{% page-ref page="download-document.md" %}
+{% hint style="warning" %}
+The `buyerAccountNumber` should be set on forehand in the Tradecloud connection with your buyer. You can set the account code when inviting a new connection or in the connection overview in the portal.
+{% endhint %}
 
 ### Order status
 
@@ -91,23 +97,40 @@ The order **logistics** status is one of:
 
 ### Buyer line
 
-`lines.buyerLine` is an echo of your order line fields as explained in [Issue a new order](../issue/#lines)
+`buyerLine` contains the buyer order line fields:
 
 * `position`: the line position within the purchase order
+* `description`: a free format additional description of this line
+* `item`: the item (or article, goods) to be delivered, see [Item](#item)
+* `requests`: the buyer can request different delivery schedule, prices and charge lines. Advised is to use the `statusLine.deliveryScheduleInclRequests` and `statusLine.pricesInclRequests` fields instead.
+* `terms`: the line terms as agreed with your buyer
+  * `contractNumber`: the agreed framework contract number
+  * `contractPosition`: the related position within the framework contract
+* `projectNumber`: The buyer's project number reference
+* `productionNumber`:  The buyer's production number reference
+* `salesOrderNumber`:  The buyer's sales order number \(not be confused with your sales order number\)
+* `indicators.noDeliveryExpected`: No goods are expected to be delivered to the buyer, for example a service, fee or text line.
+* `indicators.delivered`: All goods are delivered at the buyer.
+* `properties`: are key-value based custom fields. `\n` may be used for a new line in the value.
+* `notes`: are simple custom fields. `\n` may be used for a new line.
+* `labels`: value-added services labels on line level.
+* `documents`: contain meta data and link of attached documents, see:
+
+{% page-ref page="download-document.md" %}
+
+#### Item
+
+`lines.buyerLine.item`: The item (or article, goods) to be delivered.
+
+* `number`: the item code or number as known in the buyer ERP system.
+* `revision`: the revision (or version) of this item number
+* `name`: the item short name
+* `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`
+* `supplierItemNumber`: the item code or number as known at the supplier.
 
 ### Supplier line
 
-`lines.supplierLine` contains the supplier order line fields:
-
-* `salesOrderNumber`: the sales order number as known in the supplier's ERP system
-* `salesOrderPosition`: the position within the supplier's sales order
-* `description`: a free format additional description of this line by the supplier
-* `requests`: the supplier can request different delivery schedule, prices and charge lines. Advised is to use the `statusLine.deliveryScheduleInclRequests` and `statusLine.pricesInclRequests` fields instead.
-* `properties`: are key-value based custom fields, added by the supplier
-* `notes`: are simple custom fields, added by the supplier
-* `documents`: contain meta data, objectId or url, of attached documents by the supplier.
-
-{% page-ref page="download-document.md" %}
+`supplierLine` is an echo of your order line fields as explained in [Send order response](../send-order-response/)​.
 
 ### Status line
 

--- a/order/supplier/receive/simple-order-event.md
+++ b/order/supplier/receive/simple-order-event.md
@@ -2,7 +2,7 @@
 description: How to receive a simple order sent by the buyer.
 ---
 
-# Receive an order
+# Simple Order Event
 
 Tradecloud will send a purchase order, either new or updated, to the supplier when an order event has been triggered.
 

--- a/order/supplier/receive/simple-order-event.md
+++ b/order/supplier/receive/simple-order-event.md
@@ -6,9 +6,13 @@ description: How to receive a simple order sent by the buyer.
 
 Tradecloud will send a purchase order, either new or updated, to the supplier when an order event has been triggered.
 
-## `simpleOrderEvent`
-
 This page assumes you are using the webhook with the simple delivery schedule in the `simpleOrderEvent`.
+
+When choosing polling or the native delivery schedule in the `orderEvent` please continue on:
+
+{% page-ref page="README.md" %}
+
+## `simpleOrderEvent` header
 
 * `orderId`: the Tradecloud order identifier.
 * `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order).
@@ -55,7 +59,7 @@ The order status is the aggregation of all the lines statuses.
 #### Order process status
 
 {% hint style="info" %}
-The order **process** status is one of:
+The order process status is one of:
 
 * `Issued`: the order is \(re\)issued by the buyer.
 * `InProgress`: the order is under negotiation between buyer and supplier
@@ -68,7 +72,7 @@ The order **process** status is one of:
 #### Order logistics status
 
 {% hint style="info" %}
-The order **logistics** status is one of:
+The order logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the order full quantity is produced by the supplier
@@ -78,7 +82,7 @@ The order **logistics** status is one of:
 * `Cancelled`: the order is cancelled by the buyer
 {% endhint %}
 
-## Order lines
+## `simpleOrderEvent` lines
 
 `lines` contains one or more order lines:
 
@@ -159,7 +163,7 @@ These additional logistics fields are only available in the status line schedule
 ##### Scheduled delivery logistics status
 
 {% hint style="info" %}
-The delivery line **logistics** status is one of:
+The delivery line logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the delivery line quantity is produced by the supplier
@@ -196,7 +200,7 @@ It is advised to only use `netPrice` for its simplicity, or alternatively use `g
 #### Line process status
 
 {% hint style="info" %}
-The line **process** status is one of:
+The line process status is one of:
 
 * `Issued`: the line is \(re\)issued by the buyer
 * `InProgress`: the line is under negotiation between buyer and supplier
@@ -209,7 +213,7 @@ The line **process** status is one of:
 #### Line in Progress status
 
 {% hint style="info" %}
-The line **in progress** status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
+The line in progress status is a more fine-grained status when an order line `processStatus` is `InProgress` and is one of:
 
 * `OpenSupplierProposal`: There is an open proposal from the supplier.
 * `RejectedSupplierProposal`: The proposal from the supplier was rejected and no other requests are open.
@@ -222,7 +226,7 @@ The line **in progress** status is a more fine-grained status when an order line
 #### Line logistics status
 
 {% hint style="info" %}
-The line **logistics** status is one of:
+The line logistics status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the line quantity is produced by the supplier

--- a/order/supplier/receive/simple-order-event.md
+++ b/order/supplier/receive/simple-order-event.md
@@ -17,7 +17,6 @@ When choosing polling or the native delivery schedule in the `orderEvent` please
 * `orderId`: the Tradecloud order identifier.
 * `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order).
 * `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order).
-* `lines`: one or more lines of the order, see [Order lines](#order-lines).
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
 * `status.processStatus`: is the aggregate of all lines statuses, see [Order process status](#order-process-status).
 * `status.logisticsStatus`: is the aggregate of all lines statuses, see [Order logistics status](#order-logistics-status).

--- a/order/supplier/receive/simple-order-event.md
+++ b/order/supplier/receive/simple-order-event.md
@@ -10,16 +10,16 @@ Tradecloud will send a purchase order, either new or updated, to the supplier wh
 
 This page assumes you are using the webhook with the simple delivery schedule in the `simpleOrderEvent`.
 
-* `orderId`: the Tradecloud order identifier
-* `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order)
-* `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
-* `lines`: one or more lines of the order, see [Order lines](#order-lines)
+* `orderId`: the Tradecloud order identifier.
+* `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order).
+* `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order).
+* `lines`: one or more lines of the order, see [Order lines](#order-lines).
 * `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines' [Order process statuses](#order-process-status).
-* `status.logisticsStatus`: is the aggregate of all lines' [Order logistics statuses](#order-logistics-status).
-* `version`: the Tradecloud order version number
-* `eventDates`: some key order event date/times
-* `meta`: meta information, including source and trace info, about this messsage
+* `status.processStatus`: is the aggregate of all lines statuses, see [Order process status](#order-process-status).
+* `status.logisticsStatus`: is the aggregate of all lines statuses, see [Order logistics status](#order-logistics-status).
+* `version`: the Tradecloud order version number.
+* `eventDates`: some key order event date/times.
+* `meta`: meta information, including source and trace info, about this messsage.
 * `lastUpdatedAt`: is the latest date time the order has been changed.
 
 ### Buyer order
@@ -33,7 +33,7 @@ This page assumes you are using the webhook with the simple delivery schedule in
 * `properties`: are key-value based custom fields, added by the buyer.
 * `notes`: are simple custom fields, added by the buyer.
 * `labels`: value-added services labels on order level.
-* `documents`: contain meta data, objectId or url, of attached documents by the buyer, see:
+* `documents`: contain meta data, objectId or url, of attached documents by the buyer.
 * `orderType`: the order type, one of `Purchase` or `Forecast`.
 
 {% page-ref page="download-document.md" %}
@@ -134,7 +134,7 @@ The order **logistics** status is one of:
 
 ### Status line
 
-`lines.statusLine` represents the current order line values related to the current `Issued`, `Confirmed` or `InProgress` status. The `InclRequests` fields include the `InProgress` status and open buyer or supplier request values.
+`lines.statusLine` represents the current order line values related to the current `Issued`, `Confirmed` or `InProgress` process status. The `InclRequests` fields also include the `InProgress` status and related open buyer or supplier request values.
 
 #### Simple delivery schedule
 
@@ -226,9 +226,9 @@ The line **logistics** status is one of:
 
 * `Open`: no or partial quantity Produced, ReadyToShip, Shipped or Delivered
 * `Produced`: the line quantity is produced by the supplier
-* `ReadyToShip`: the line quantity ready to be shipped by the supplier
-* `Shipped`: the line quantity shipped by the supplier
-* `Delivered`: the line quantity delivered at the buyer
+* `ReadyToShip`: the line quantity is ready to be shipped by the supplier
+* `Shipped`: the line quantity is shipped by the supplier
+* `Delivered`: the line quantity is delivered at the buyer
 * `Cancelled`: the line is cancelled by the buyer
 {% endhint %}
 


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-8713 In progress status story
https://tradecloud.atlassian.net/browse/TC-9481 Alert about Polling and "open" buyer reopen request in API docs. 
https://tradecloud.atlassian.net/browse/TC-9467 Alert about Polling and "open" buyer reopen request in API docs (superseded)

Please review: https://app.gitbook.com/o/-LNyIUZSvpZWZ81yEr7V/s/-LNyJ9UuwLCjTvA2sqQR-887967055/~/revisions/nZCqdUTDMvvrpj07rcDN/

### Scope
This PR 
- explains how to handle echoed changes in an open request when using polling
- replaces `lastUpdatedAt` by `lastUpdatedSince` (https://tradecloud.atlassian.net/browse/TC-9408)
- improves polling documentation by splitting up webhook versus polling and polling usage
- splits supplier API native and simple delivery schedule pages

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
