### PR TITLE
 [TC-9408] Rename `lastUpdatedSince` filter to `lastUpdatedAfter`

### DIFF
--- a/api/webhook-vs-polling.md
+++ b/api/webhook-vs-polling.md
@@ -129,9 +129,9 @@ Con's:
 
 #### Step 1. Fetch updated orders or shipments periodically
 
-Fetch every polling period, typically 5 minutes, all orders or shipments which are new or changed since last date time.
+Fetch every polling period, typically 5 minutes, all orders or shipments which are new or changed after last date time.
 
-* Use the latest `lastUpdatedAt` from previous poll request in the `lastUpdatedSince` filter.
+* Use the latest `lastUpdatedAt` from previous poll request in the `lastUpdatedAfter` filter, which will fetch only updated orders after last date time.
 * Sorting is set automatically to `lastUpdatedAt` order `asc` \(the latest `lastUpdatedAt` will be in the last order or shipment in the response body\)
 * Set `limit` to the maximum of `100` orders or shipments.
 * Optionally use `offset` for paging, but if you receive more than `100` orders or shipments, it is easier to reduce the polling period, so you receive less orders or shipments per request.
@@ -154,9 +154,9 @@ See the [Search shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://
 
 #### Step 3. Store the `lastUpdatedAt` for the next polling request
 
-Store the **latest** \(in the last order or shipment in the response body\) `lastUpdatedAt` to be used as `lastUpdatedSince` in the next polling request.
+Store the **latest** \(in the last order or shipment in the response body\) `lastUpdatedAt` to be used as `lastUpdatedAfter` in the next polling request.
 
 * `lastUpdatedAt` has type `String` with format `YYYY-MM-DDThh:mm:ss.SSSZ`, but to keep it simple just store it as a `String`.
 * The latest `lastUpdatedAt` should be stored **persistent**. When your integration is restarted or crashes, `lastUpdatedAt` should still be available.
-* If there is no order in the order or shipment response body, use the same `lastUpdatedSince` in the next polling request.
-* The very first time, use a date in the past, from the point you want to receive existing order responses.
+* If there is no order in the order or shipment response body, use the same `lastUpdatedAfter` in the next polling request.
+* The very first time, use a date in the past, from the point you want to receive existing orders.

--- a/api/webhook-vs-polling.md
+++ b/api/webhook-vs-polling.md
@@ -131,7 +131,7 @@ Con's:
 
 Fetch every polling period, typically 5 minutes, all orders or shipments which are new or changed after last date time.
 
-* Use the latest `lastUpdatedAt` from previous poll request in the `lastUpdatedAfter` filter, which will fetch only updated orders after last date time.
+* Use the latest `lastUpdatedAt` from previous poll request in the `lastUpdatedAfter` filter, which will only return orders that are updated after this date time.
 * Sorting is set automatically to `lastUpdatedAt` order `asc` \(the latest `lastUpdatedAt` will be in the last order or shipment in the response body\)
 * Set `limit` to the maximum of `100` orders or shipments.
 * Optionally use `offset` for paging, but if you receive more than `100` orders or shipments, it is easier to reduce the polling period, so you receive less orders or shipments per request.


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-9408

https://app.gitbook.com/o/-LNyIUZSvpZWZ81yEr7V/s/-LNyJ9UuwLCjTvA2sqQR-887967055/~/revisions/WoY9EC9u3vynV5K5XO0C/introduction/api/webhook-vs-polling#polling-usage

### Scope
This PR renames the `lastUpdatedSince` filter to `lastUpdatedAfter`

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
