### PR TITLE
[TC-10053] Add order response endpoints

### DIFF
--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -33,7 +33,7 @@ Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https:
 
 Use the [POST poll](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute) endpoint.
 
-* `order` contains the actual order
+* `order` contains the actual order in its current state
 
 ## `orderEvent` or `order` header
 

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -22,6 +22,19 @@ When choosing single delivery please continue on:
 
 {% page-ref page="single-delivery-order-response.md" %}
 
+## When working with the webhook API
+
+Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+
+* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events) when working with the POST order webhook API
+* `orderEvent` contains the actual order event
+
+## When working with the polling API
+
+Use the [POST poll](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute) endpoint.
+
+* `order` contains the actual order
+
 ## `orderEvent` or `order` header
 
 This page assumes you either chose delivery schedules using the `orderEvent` webhook API or the `order` polling API.

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -26,7 +26,7 @@ When choosing single delivery please continue on:
 
 Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
 
-* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events) when working with the POST order webhook API
+* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events)
 * `orderEvent` contains the actual order event
 
 ## When working with the polling API

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -31,7 +31,7 @@ Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https:
 
 Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) endpoint.
 
-* `order` contains the actual order
+* `order` contains the actual order in its current state
 
 ## `singleDeliveryOrderEvent` or `order` header
 

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -24,7 +24,7 @@ The `deliverySchedule.position` will be mapped to the order response `lines.buye
 
 Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
 
-* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events) when working with the POST order webhook API
+* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events)
 * `singleDeliveryOrderEvent` contains the actual order event
 
 ## When working with the polling API

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -20,6 +20,19 @@ In the single delivery order response Tradecloud will split the delivery schedul
 The `deliverySchedule.position` will be mapped to the order response `lines.buyerLine.position`
 {% endhint %}
 
+## When working with the webhook API
+
+Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+
+* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events) when working with the POST order webhook API
+* `singleDeliveryOrderEvent` contains the actual order event
+
+## When working with the polling API
+
+Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) endpoint.
+
+* `order` contains the actual order
+
 ## `singleDeliveryOrderEvent` or `order` header
 
 * `id` (in case of an `order`): the Tradecloud order identifier

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -22,6 +22,19 @@ When choosing the single delivery please continue on:
 
 {% page-ref page="single-delivery-order.md" %}
 
+## When working with the webhook API
+
+Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+
+* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events) when working with the POST order webhook API
+* `orderEvent` contains the actual order event
+
+## When working with the polling API
+
+Use the [POST poll](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute) endpoint.
+
+* `order` contains the actual order
+
 ## `orderEvent` or `order` header
 
 This page assumes you either chose the `orderEvent` webhook API or the `order` polling API.

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -26,7 +26,7 @@ When choosing the single delivery please continue on:
 
 Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
 
-* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events) when working with the POST order webhook API
+* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events)
 * `orderEvent` contains the actual order event
 
 ## When working with the polling API

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -33,7 +33,7 @@ Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https:
 
 Use the [POST poll](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute) endpoint.
 
-* `order` contains the actual order
+* `order` contains the actual order in its current state
 
 ## `orderEvent` or `order` header
 

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -16,7 +16,7 @@ When choosing the delivery schedule please continue on:
 
 Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
 
-* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events) when working with the POST order webhook API
+* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events)
 * `singleDeliveryOrderEvent` contains the actual order event
 
 ## When working with the polling API

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -23,7 +23,7 @@ Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https:
 
 Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) endpoint.
 
-* `order` contains the actual order
+* `order` contains the actual order in its current state
 
 ## `singleDeliveryOrderEvent` or `order` header
 

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -12,6 +12,19 @@ When choosing the delivery schedule please continue on:
 
 {% page-ref page="README.md" %}
 
+## When working with the webhook API
+
+Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+
+* `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events) when working with the POST order webhook API
+* `singleDeliveryOrderEvent` contains the actual order event
+
+## When working with the polling API
+
+Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) endpoint.
+
+* `order` contains the actual order
+
 ## `singleDeliveryOrderEvent` or `order` header
 
 * `id` (in case of an `order`): the Tradecloud order identifier


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-10053

review: https://app.gitbook.com/o/-LNyIUZSvpZWZ81yEr7V/s/-LNyJ9UuwLCjTvA2sqQR-887967055/~/revisions/NTiRiNqMmH7aC76DxTqO/

### Scope
This PR ......
- re-adds order response endpoints (they were deleted at some point, and developers could not find them anymore)
- adds references to the order event names

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [ ] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
