### PR TITLE
docs: [TC-10147] Remove mentions of GET and reword usage of POST webhook

### DIFF
--- a/api/delivery-schedule.md
+++ b/api/delivery-schedule.md
@@ -28,7 +28,7 @@ The field `lines.deliverySchedule` contains the delivery schedule of this order 
 
 When receiving an order response, the "Orders Webhook Integration" setting "My system supports" must be set to the default "**Multiple deliveries per order line**".
 
-Use the `orderEvent` field of the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+Use the `orderEvent` field of the [order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
 
 The field `lines.deliverySchedule` contains the current delivery schedule of this order line.
 
@@ -61,7 +61,7 @@ Tradecloud will merge `scheduledDelivery`'s of order lines with the same item, p
 
 When receiving an order response, you must have the "Orders Webhook Integration" setting "My system supports" set to "**Only one single delivery per order line**".
 
-Use the `singleDeliveryOrderEvent` field of the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+Use the `singleDeliveryOrderEvent` field of the [order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
 
 The field `lines.statusLine.scheduledDelivery` contains the current scheduled delivery of this order line.
 
@@ -69,10 +69,6 @@ The field `lines.statusLine.scheduledDelivery` contains the current scheduled de
 
 {% hint style="warning" %}
 The order line `position` may be unassigned in case of an order line split by a supplier. The ERP system must assign a position to the split order line and update the order line to Tradecloud.
-{% endhint %}
-
-{% hint style="warning" %}
-The single delivery per order line is supported by the POST webhook API and polling API, but not supported by the GET webhook API.
 {% endhint %}
 
 ### `scheduledDelivery` fields

--- a/api/json-vs-xml.md
+++ b/api/json-vs-xml.md
@@ -22,7 +22,7 @@ You can see an XML example by selecting "application/xml" in the "Parameter cont
 
 ![Select order API XML content type](../.gitbook/assets/select-order-api-xml-content-type.png)
 
-Also the [POST Order Webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint supports `tXML`.
+Also the [Order Webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint supports `tXML`.
 
 You can see an XML example by selecting "application/xml" in the "Parameter content type" dropdown, under the "Example Value" in above API specification:
 

--- a/api/requests.md
+++ b/api/requests.md
@@ -8,7 +8,7 @@ description: How to make API requests
 
 An API request consist of:
 
-* [HTTP method](requests.md#HTTP-method): `GET`, `POST`, `PUT` or `DELETE`
+* [HTTP method](requests.md#HTTP-method): `GET`, `POST` or `DELETE`
 * [HTTP headers](requests.md#HTTP-headers): authorization and content type
 * [URL](requests.md#URL): HTTPS, environment, service, method and parameters
 * [JSON body](requests.md#json-body) which contains the payload
@@ -19,7 +19,6 @@ The API supports
 
 * `GET` to get a specific JSON object, like a purchase order, or to download a document \(one JSON object or document is returned\) or to query objects \(a JSON collection is returned\)
 * `POST` to create a new JSON object or upload a document
-* `PUT` to update an existing JSON object
 * `DELETE` to delete an existing JSON object or document
 
 ## HTTP headers

--- a/api/webhook-vs-polling.md
+++ b/api/webhook-vs-polling.md
@@ -7,8 +7,7 @@ description: >-
 
 To receive an order, order response or shipment message you can use either:
 
-* The [Webhook Connector](https://tradecloud.gitbook.io/connectors/webhook-connector) using `POST`.
-* The [Webhook Connector](https://tradecloud.gitbook.io/connectors/webhook-connector) using `GET`.
+* The [Webhook Connector](https://tradecloud.gitbook.io/connectors/webhook-connector).
 * The polling pattern.
 
 ## The Webhook Connector
@@ -17,29 +16,23 @@ When an order or shipment has been changed at Tradecloud, we will trigger your w
 
 The webhook is most suitable for companies with real time, high volume orders and having a web server or integration platform, firewall and SSL certificate available.
 
-You can either use `POST` to receive order or shipment content or alternatively `GET` to only receive an `orderId` or `shipmentId`.
+We will send a `POST` request to your webhook containing the order or shipment content.  See the [Webhook Connector Documentation](https://tradecloud.gitbook.io/connectors/webhook-connector) for more information.
 
-See [Webhook Connector](https://tradecloud.gitbook.io/connectors/webhook-connector) for setting up and using the webhook.
+### `POST` Request Content
 
-### Using `POST`
-
-To receive order event messages use the [POST Order Webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
-
-When using `POST` the order webhook request body contains:
+By using the [Order Webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint for orders, you can receive order event messages. The order webhook `POST` request body sent by Tradecloud contains:
 
 * `eventName`: The event name summarizes what has happened.
 * `orderEvent`: The order event, when using a delivery schedule.
 * `singleDeliveryOrderEvent`: The order event, when using only one single delivery per order line.
 * `orderDocumentsEvent`: The order documents event, when using documents.
 
-To receive shipment event messages use the [POST Shipment Webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment-webhook-connector/specs.yaml#/shipment-webhook%20endpoints/webhookPost) endpoint.
-
-When using `POST` the shipment webhook request body contains:
+By using the [Shipment Webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment-webhook-connector/specs.yaml#/shipment-webhook%20endpoints/webhookPost) endpoint for shipments, you can receive the shipment contents. The shipment webhook `POST` request body sent by Tradecloud contains:
 
 * `eventName`: The event name summarizes what has happened.
 * `shipment`: The actual shipment.
 
-Use `POST` when:
+Use the webhook when:
 
 * You want to receive real time order or shipment events.
 * You want to receive the order event or shipment event content.
@@ -53,50 +46,13 @@ Pro's:
 * Real time, receive the order or shipment event within a second.
 * Order or shipment event content included.
 * You can filter on which order or shipment events to receive, in the order & shipment webhook settings in your company settings or filter events yourself in your integration.
-* You can use the single delivery per order line feature.
 * You can choose to use XML instead of JSON.
 * You do not have to build or configure the polling pattern.
 
 Con's:
 
 * You need to build or configure a webhook at your side.
-* You need to publish the webhook on the internet \(webserver and firewall required\).
-* You need to obtain and configure a public SSL certificate.
-{% endhint %}
-
-### Using `GET`
-
-The `GET` endpoint is an alternative to the `POST` endpoint and can be used to receive the `orderId` or `shipmentId` of the order or shipment that has been changed.
-
-To receive the `orderId` use the [GET Order Webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookGet) endpoint.
-
-When using `GET` the webhook request URL will contain the Tradecloud `orderId`, which you must use to fetch the order.
-
-To receive the `shipmentId` use the [GET Shipment Webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment-webhook-connector/specs.yaml#/shipment-webhook%20endpoints/webhookGet) endpoint.
-
-When using `GET` the webhook request URL will contain the Tradecloud `shipmentId`, which you must use to fetch the shipment.
-
-Use `GET` when:
-
-* Same as `POST` above, but:
-* You need to receive the **complete** order with **all** the order lines, regardless they are changed or not.
-* You can handle the delivery schedule yourself.
-
-{% hint style="info" %}
-Pro's:
-
-* Real time, receive the order or shipment within a second.
-* You can filter on which order or shipment events to receive, in the order & shipment webhook settings in your company profile.
-* You do not have to build or configure the polling pattern.
-
-Con's:
-
-* You need to fetch the order or shipment.
-* You cannot see what order or shipment event happened.
-* You cannot use the single delivery per order line feature.
-* You cannot choose XML, but must use JSON.
-* You need to build or configure a webhook at your side.
-* You need to publish the webhook on the internet \(web server and firewall required\).
+* You need to publish the webhook on the Internet \(webserver and firewall required\).
 * You need to obtain and configure a public SSL certificate.
 {% endhint %}
 

--- a/api/webhook-vs-polling.md
+++ b/api/webhook-vs-polling.md
@@ -12,7 +12,7 @@ To receive an order, order response or shipment message you can use either:
 
 ## The Webhook Connector
 
-When an order or shipment has been changed at Tradecloud, we will trigger your webhook.
+When an order or shipment has been changed at Tradecloud, we will trigger your webhook realtime.
 
 The webhook is most suitable for companies with real time, high volume orders and having a web server or integration platform, firewall and SSL certificate available.
 


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-10147

### Scope
This PR updates the documentation to remove the mentions of the GET Order Webhook, and reword the usage of POST requests, to make this read more like it is the default.

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
