### PR TITLE
[TC-10243] add optional item number

### DIFF
--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -104,7 +104,7 @@ The optional buyer, buyer accounting or supplier company party:
 * `supplierItemNumber`: the item code or number as known at the supplier. Required in case of wholesale suppliers.
 
 {% hint style="warning" %}
-`item.number` and `item.supplierItemNumber` are optional and may be left empty, for example in case of service or RFQ orders or text lines.
+`item.number` and `item.supplierItemNumber` are optional and may be left empty, for example in case of service or RFQ orders.
 
 Leaving the `item.number` and `item.supplierItemNumber` both empty is not recommended for integrated suppliers, as the supplier might reject the order line.
 

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -104,7 +104,11 @@ The optional buyer, buyer accounting or supplier company party:
 * `supplierItemNumber`: the item code or number as known at the supplier. Required in case of wholesale suppliers.
 
 {% hint style="warning" %}
-`item.number` should be unique within your company and never change. Never renumber or re-use `item.number`s.
+`item.number` and `item.supplierItemNumber` are optional and may be left empty, for example in case of service or RFQ orders or text lines.
+
+Leaving the `item.number` and `item.supplierItemNumber` both empty is not recommended for integrated suppliers, as the supplier might reject the order line.
+
+`item.number` should be unique within the buyer's company and never change. Never renumber or re-use `item.number`s.
 {% endhint %}
 
 ### Item details

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -108,7 +108,7 @@ The optional buyer, buyer accounting or supplier company party:
 
 Leaving the `item.number` and `item.supplierItemNumber` both empty is not recommended for integrated suppliers, as the supplier might reject the order line.
 
-`item.number` should be unique within the buyer's company and never change. Never renumber or re-use `item.number`s.
+`item.number` should be unique within the buyer's company and never change. Never renumber or re-use `item.number`s for a different item.
 {% endhint %}
 
 ### Item details

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -162,7 +162,7 @@ The order logistics status is one of:
 * `supplierItemNumber`: the item code or number as known at the supplier.
 
 {% hint style="warning" %}
-`item.number` and `supplierItemNumber` are optional and may be left empty by the buyer, for example in case of service or RFQ orders or text lines.
+`item.number` and `supplierItemNumber` are optional and may be left empty by the buyer, for example in case of service or RFQ orders.
 
 If the supplier cannot process the order line without `item.number` or `item.supplierItemNumber`, the supplier should reject the order line and provide a reason.
 

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -161,6 +161,14 @@ The order logistics status is one of:
 * `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`
 * `supplierItemNumber`: the item code or number as known at the supplier.
 
+{% hint style="warning" %}
+`item.number` and `supplierItemNumber` are optional and may be left empty by the buyer, for example in case of service or RFQ orders or text lines.
+
+If the supplier cannot process the order line without `item.number` or `item.supplierItemNumber`, the supplier should reject the order line and provide a reason.
+
+`item.number` should be unique within the buyer's company and should never change.
+{% endhint %}
+
 #### Buyer requests
 
 `lines.buyerLine.requests.reopenRequest`: the buyer requests to reopen the confirmed order line. The buyer has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -36,10 +36,6 @@ When the order line has process status `Confirmed`:
 * When the by supplier **responded** `delivery schedule` and `prices` are **NOT** equal to the **confirmed** `delivery schedule` and `prices` the process status will become `InProgress` and a **reopen request** task for the buyer will be created.
 * When the **responded** `delivery schedule` and `prices` are **equal** to the **confirmed** `delivery schedule` and `prices` the process status will stay `Confirmed`
 
-{% hint style="warning" %}
-This [reopen request](../reopen.md) feature is under development and API and documentation may change.
-{% endhint %}
-
 When the order line already has process status `Rejected`the process status will **NOT** change.
 
 When the order line already has process status `Completed` the process status will **NOT** change.
@@ -130,17 +126,17 @@ When sending a new delivery line do NOT provide a `position`. The buyer will ass
 ### Responded prices
 
 * `lines.prices`: the responded price. Advised is to provide only `netPrice` for its simplicity, or alternatively `grossPrice` together with `discountPercentage`. 
-    * `grossPrice`: the gross price. Used together with `discountPercentage`.
-    * `discountPercentage`: the discount percentage. Used together with `grossPrice`.
-    * `netPrice`: the net price.
-      * `priceInTransactionCurrency`: at least provide a price in the transaction currency, like `CNY` in China.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
-      * `priceInBaseCurrency`: optionally provide a price in your base currency, like `EUR` in the EU.
-        * `value`: the price value has a decimal `1234.56` format with any number of digits.
-        * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-    * `priceUnitOfMeasureIso`: the price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-    * `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
+  * `grossPrice`: the gross price. Used together with `discountPercentage`.
+  * `discountPercentage`: the discount percentage. Used together with `grossPrice`.
+  * `netPrice`: the net price.
+    * `priceInTransactionCurrency`: at least provide a price in the transaction currency, like `CNY` in China.
+      * `value`: the price value has a decimal `1234.56` format with any number of digits.
+      * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
+    * `priceInBaseCurrency`: optionally provide a price in your base currency, like `EUR` in the EU.
+      * `value`: the price value has a decimal `1234.56` format with any number of digits.
+      * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
+  * `priceUnitOfMeasureIso`: the price unit according to ISO 80000-1. The purchase unit and price unit may be different.
+  * `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
 
 ### Responded charge lines
 
@@ -167,7 +163,7 @@ When sending a new charge line do NOT provide a `position`. The buyer will assig
 
 * `description`: a free format additional description of this line
 * `indicators.accepted`: explicitly **accept** the order line as is, the responded `delivery schedule` and `prices` will be ignored.
-* `indicators.rejected`: explicitly **reject** the order line, the responded`delivery schedule` and `prices`will be ignored. When possible provide the `reason` , see below.
+* `indicators.rejected`: explicitly **reject** the order line, the responded`delivery schedule` and `prices`will be ignored. When possible provide the `reason`, see below.
 * Additional `indicators`:
 
 {% page-ref page="../cancel.md" %}


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-10243

review: https://app.gitbook.com/o/-LNyIUZSvpZWZ81yEr7V/s/-LNyJ9UuwLCjTvA2sqQR-887967055/~/revisions/otS0uDAU8rFonQHOw0z1/

### Scope
This PR adds the optional item number to the buyer issue and supplier receive pages.
Also cleans up the supplier send order response page 

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [ ] Review your documentation
- [ ] Add labels `needs reviewing`
- [ ] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'
