### PR TITLE
[TC-10289] order response optional delivery schedule position

### DIFF
--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -117,9 +117,9 @@ The supplier may check, change and add item details if they are not correct or i
   * `position`: an optional position in the delivery schedule, distinct from `line.position`.
 
 {% hint style="warning" %}
-* The supplier must either echo the `deliverySchedule.position` as received from the buyer or leave it empty.
+* The supplier must either echo the `position` as received from the buyer or leave it empty.
 * When sending a new split delivery line, do not provide a `position`; the buyer will assign it.
-* If `deliverySchedule.position` is left empty, the supplier must preserve the order of the original delivery schedule sent by the buyer.
+* If `position` is left empty, the supplier must preserve the order of the original delivery schedule sent by the buyer.
 * Any new split delivery line should be appended to the end of the delivery schedule.
 {% endhint %}
 
@@ -149,7 +149,7 @@ The supplier may check, change and add item details if they are not correct or i
   * `position`: the position used to identify a charge line.  
 
 {% hint style="warning" %}
-* The supplier must echo the `chargeLines.position` as received from the buyer. 
+* The supplier must echo the `position` as received from the buyer. 
 * When sending a new charge line, do not provide a `position`; the buyer will assign it.
 {% endhint %}
 

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -111,17 +111,22 @@ The supplier may check, change and add item details if they are not correct or i
 * `serialNumber`: is an unique identifier assigned incrementally or sequentially to an item, to uniquely identify it.
 * `batchNumber`: is an identification number assigned to a particular quantity or lot of material from a single manufacturer
 
-### Responded planned delivery schedule
+### Responded delivery schedule
 
-* `lines.deliverySchedule`: the responded planned delivery schedule. Provide at least one or multiple delivery schedule lines.
-  * `position`: the optional position in the delivery schedule. Not to be confused with the `line.position`.
+* `lines.deliverySchedule`: the responded delivery schedule. At least one delivery schedule line must be provided.
+  * `position`: an optional position in the delivery schedule, distinct from `line.position`.
+
+{% hint style="warning" %}
+* The supplier must either echo the `deliverySchedule.position` as received from the buyer or leave it empty.
+* When sending a new split delivery line, do not provide a `position`; the buyer will assign it.
+* If `deliverySchedule.position` is left empty, the supplier must preserve the order of the original delivery schedule sent by the buyer.
+* Any new split delivery line should be appended to the end of the delivery schedule.
+{% endhint %}
+
+* `lines.deliverySchedule`:
   * `date`: the responded delivery date of this delivery schedule position.  If the delivery date is yet unknown, leave this date empty.  If the date is not equal to the requested date, when possible provide a `reason` , see below. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
   * `quantity`: the responded quantity of this delivery schedule position.  If the quantity that can be delivered is yet unknown, leave this quantity empty.  If the quantity is not equal to the requested date, when possible provide a `reason` , see below. Quantity has a decimal `1234.56` format with any number of digits.
 
-{% hint style="warning" %}
-The supplier must echo the `deliverySchedule.position` as sent by the buyer.
-When sending a new delivery line do NOT provide a `position`. The buyer will assign a `position`.
-{% endhint %}
 
 ### Responded prices
 
@@ -142,6 +147,12 @@ When sending a new delivery line do NOT provide a `position`. The buyer will ass
 
 * `lines.chargeLines`: the requested additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
   * `position`: the position used to identify a charge line.  
+
+{% hint style="warning" %}
+* The supplier must echo the `chargeLines.position` as received from the buyer. 
+* When sending a new charge line, do not provide a `position`; the buyer will assign it.
+{% endhint %}
+
   * `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
   * `chargeDescription`: a mandatory free text description, like "Transport costs".
   * `quantity`: the mandatory quantity of this charge line.
@@ -153,11 +164,6 @@ When sending a new delivery line do NOT provide a `position`. The buyer will ass
       * `value`: the price value has a decimal `1234.56` format with any number of digits.
       * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
   * `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1 which applies to the charge line price.
-
-{% hint style="warning" %}
-The supplier must echo the `chargeLines.position` as sent by the buyer. 
-When sending a new charge line do NOT provide a `position`. The buyer will assign a `position`.
-{% endhint %}
 
 #### Other line fields
 

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -153,6 +153,7 @@ The supplier may check, change and add item details if they are not correct or i
 * When sending a new charge line, do not provide a `position`; the buyer will assign it.
 {% endhint %}
 
+* `lines.chargeLines`:
   * `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
   * `chargeDescription`: a mandatory free text description, like "Transport costs".
   * `quantity`: the mandatory quantity of this charge line.

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -125,7 +125,7 @@ The supplier may check, change and add item details if they are not correct or i
 
 * `lines.deliverySchedule`:
   * `date`: the responded delivery date of this delivery schedule position.  If the delivery date is yet unknown, leave this date empty.  If the date is not equal to the requested date, when possible provide a `reason` , see below. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-  * `quantity`: the responded quantity of this delivery schedule position.  If the quantity that can be delivered is yet unknown, leave this quantity empty.  If the quantity is not equal to the requested date, when possible provide a `reason` , see below. Quantity has a decimal `1234.56` format with any number of digits.
+  * `quantity`: the responded quantity of this delivery schedule position.  If the quantity that can be delivered is yet unknown, leave this quantity empty.  If the quantity is not equal to the requested quantity, when possible provide a `reason`, see below. Quantity has a decimal `1234.56` format with any number of digits.
 
 
 ### Responded prices


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-10289

please review https://docs.tradecloud1.com/api/~/revisions/VAz0FoAJsZozKECSzXGR/processes/order/supplier/send-order-response#responded-delivery-schedule

### Scope
This PR 
- adds the order response optional delivery schedule position
- improves warnings regarding this optional delivery schedule position

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [x] Add labels `needs reviewing`
- [x] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the delivery schedule section header for improved clarity.
  - Revised the field descriptions to indicate that at least one delivery schedule line is required.
  - Clarified the handling of the optional position field, ensuring it is distinct from the line’s position.
  - Expanded details regarding the date, quantity, and format requirements for delivery schedule and charge lines, along with guidance on preserving the order of entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->