### PR TITLE
[TC-10478] add response level `lastUpdateAt` to polling

### DIFF
--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -1,60 +1,127 @@
 ---
 description: >-
-  How to use the polling pattern.
+  Implementation guide for the polling pattern in Tradecloud API v2
 ---
 
-# Polling usage
+# Polling Pattern Implementation Guide
 
-The polling API is an alternative for the webhook API. The pro's and cons are explained in:
+The polling API offers an alternative to the webhook API for retrieving order updates. Both approaches have different advantages and considerations:
 
 {% page-ref page="../webhook-vs-polling.md" %}
 
-This page explains the polling pattern usage, which consists of 3 steps:
+## Overview
 
-1. Fetch the orders or shipments which are changed after last time.
-2. Process the fetched, either new or updated, orders or shipments.
-3. Persist the latest `data.lastUpdatedAt`.
+The polling pattern consists of three essential steps:
 
-## Step 1. Fetch updated orders or shipments periodically
+1. **Fetch** - Retrieve orders or shipments changed since the last poll
+2. **Process** - Handle the retrieved new or updated data
+3. **Persist** - Store the latest timestamp for the next polling cycle
 
-Every polling period, fetch all orders or shipments which are new or changed after last time. A polling period is typically 5 minutes.
+## Implementation steps
 
-* Use the latest `data.lastUpdatedAt` from previous poll request in the `lastUpdatedAfter` filter.
-* Sorting is set to `data.lastUpdatedAt` (`asc`) by default when the `lastUpdatedAfter` filter is applied. The last updated order or shipment will be ordered last in the response body.
-* Set `limit` to the maximum of `100` orders or shipments.
-* If the response body contains a `total` of more than `100`, it means that not all recently updated orders or shipments were returned. You can either:
-  * Decrease the polling period (advised)
-  * Use `offset` for paging, to receive the next 100 orders or shipments.
+### Step 1: Fetch updated data periodically
 
-Use the [Poll orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute) endpoint for polling orders using the delivery schedule feature.
+Set up a scheduled process to fetch all orders or shipments that have been created or changed since your last poll.
 
-Use the [Poll single delivery orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) endpoint for polling orders using the single delivery per order line feature.
+#### Polling best practices
 
-Use the [Poll shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/pollShipmentsRoute) endpoint for polling shipments.
+- Use a consistent polling interval (typically 5 minutes)
+- Include the `lastUpdatedAt` from previous poll response as the `lastUpdatedAfter` filter
+- Set `limit=100` (maximum allowed value) to control response size
+- Handle pagination when needed:
+  - If response contains `total` > 100, not all updates were returned
+  - Either decrease polling frequency (recommended) or use `offset` parameter for paging
 
-## Step 2. Process the orders or shipments in the search response body
+#### Available endpoints
 
-Process the fetched new or updated orders or shipments.
+| Data Type                  | Endpoint                                                                                                                                                                            | Use Case                                   |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Orders (delivery schedule) | [Poll orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute)                               | For orders using delivery schedule feature |
+| Orders (single delivery)   | [Poll single delivery orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) | For orders using single delivery per line  |
+| Shipments                  | [Poll shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/pollShipmentsRoute)                                 | For shipment updates                       |
+
+#### Example request
+
+```http
+GET /v2/order-search/poll
+
+{
+  "filters": {
+    "lastUpdatedAfter": "2025-04-23T10:01:53.812Z"
+  },
+  "limit": 100
+}
+```
+
+### Step 2: Process retrieved data
+
+Implement logic to handle the fetched new or updated orders or shipments.
+
+#### Example response
+```http
+{
+  "data": [
+    {
+      "supplierAccountNumber": "SUPPLIER12345",
+      "purchaseOrderNumber": "PO123456789",
+      "lines": [
+        {
+          "deliverySchedule" ...
+          "prices" ...
+          "status": {
+            "processStatus": "Issued",
+            "logisticsStatus": "Open"
+          },
+          "lastUpdatedAt": "2025-04-23T10:01:53.812Z"
+        }
+      ],
+      "status": {
+        "processStatus": "Issued",
+        "logisticsStatus": "Open"
+      },
+      "lastUpdatedAt": "2025-04-23T10:01:53.812Z"
+    }
+  ],
+  "total": 10,
+  "lastUpdatedAt": "2025-04-23T10:01:53.812Z"
+}
+```
 
 {% hint style="warning" %}
-You may receive any order or shipment change, including echoed changes from your ERP system. How to handle your own open request is explained in [Polling echo](echo.md).
+Your poll results may include outdated data in case of a request. See [Polling Echo Handling](echo.md) for managing outdated data.
 {% endhint %}
 
-When using the [Poll orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute) or [Poll single delivery orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) endpoints:
+#### Order processing tips
 
-* Optionally use the `data.lines.lastUpdatedAt` field to filter the order lines that have been changed: Only consider lines where `lines.lastUpdatedAt` is after the `lastUpdatedAfter` filter value.
-* Optionally use the `data.lines.status` fields to filter the order lines on `processStatus`, `inProgressStatus`, `logisticsStatus` and `deliveryLineStatus` fields.
+When working with order endpoints:
 
-When using the [Poll shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/pollShipmentsRoute) endpoint:
+- Use `data.lines.lastUpdatedAt` to identify which specific lines changed
+- Filter by status using `data.lines.status` fields:
+  - `processStatus`
+  - `inProgressStatus`
+  - `logisticsStatus`
+  - `deliveryLineStatus`
 
-* Optionally use the `data.lines.meta.lastUpdatedAt` to filter the shipment lines that have been changed.
-* Optionally use the `data.status` field to filter on shipment process and logistics status sub fields.
+#### Shipment processing tips
 
-## Step 3. Persist the `lastUpdatedAt` for the next polling request
+When working with shipment endpoint:
 
-Persist the **latest** \(in the last order or shipment in the response body\) `lastUpdatedAt` to be used as `lastUpdatedAfter` in the next polling request.
+- Use `data.lines.meta.lastUpdatedAt` to identify changed shipment lines
+- Filter by `data.status` to focus on relevant shipment statuses
 
-* `lastUpdatedAt` has type `String` with format `YYYY-MM-DDThh:mm:ss.SSSZ`, but to keep it simple just store it as a `String`.
-* The latest `lastUpdatedAt` should be stored **persistent**. When your integration is restarted or crashes, `lastUpdatedAt` should still be available.
-* If there is no data in the response body, use the same `lastUpdatedAfter` again in the next polling request.
-* In the very first polling request, set the `lastUpdatedAfter` to a date in the past from which you want to receive existing orders or shipments.
+### Step 3: Persist the timestamp
+
+Store the `lastUpdatedAt` value to use as `lastUpdatedAfter` in subsequent requests.
+
+#### Implementation tips
+
+- The timestamp has format `YYYY-MM-DDThh:mm:ss.SSSZ` (ISO 8601)
+- Store this in **persistent storage** (database, file system, etc.)
+- Your storage solution must survive application restarts or crashes
+- If the response contains no data, reuse your current `lastUpdatedAfter` value
+- For first-time polling, use a historical date to fetch existing records
+
+#### Edge cases
+
+- **Initial setup**: Set `lastUpdatedAfter` to retrieve historical data as needed
+- **Empty responses**: Keep using the same timestamp until you get results

--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -3,9 +3,9 @@ description: >-
   Implementation guide for the polling pattern in Tradecloud API v2
 ---
 
-# Polling Pattern Implementation Guide
+# Polling pattern implementation guide
 
-The polling API offers an alternative to the webhook API for retrieving order updates. Both approaches have different advantages and considerations:
+The polling API offers an alternative to the webhook API for retrieving order or shipment updates. Both approaches have different advantages and considerations:
 
 {% page-ref page="../webhook-vs-polling.md" %}
 
@@ -30,7 +30,7 @@ Set up a scheduled process to fetch all orders or shipments that have been creat
 - Set `limit=100` (maximum allowed value) to control response size
 - Handle pagination when needed:
   - If response contains `total` > 100, not all updates were returned
-  - Either decrease polling frequency (recommended) or use `offset` parameter for paging
+  - Either decrease the polling period (recommended) or use `offset` parameter for paging
 
 #### Available endpoints
 
@@ -58,6 +58,7 @@ GET /v2/order-search/poll
 Implement logic to handle the fetched new or updated orders or shipments.
 
 #### Example response
+
 ```http
 {
   "data": [
@@ -95,7 +96,7 @@ Your poll results may include outdated data in case of a request. See [Polling E
 
 When working with order endpoints:
 
-- Use `data.lines.lastUpdatedAt` to identify which specific lines changed
+- Use `data.lines.lastUpdatedAt` to identify which specific lines changed since the `lastUpdatedAfter` time you provided.
 - Filter by status using `data.lines.status` fields:
   - `processStatus`
   - `inProgressStatus`
@@ -106,12 +107,14 @@ When working with order endpoints:
 
 When working with shipment endpoint:
 
-- Use `data.lines.meta.lastUpdatedAt` to identify changed shipment lines
+- Use `data.lines.meta.lastUpdatedAt` to identify changed shipment lines since the `lastUpdatedAfter` time you provided.
 - Filter by `data.status` to focus on relevant shipment statuses
 
 ### Step 3: Persist the timestamp
 
 Store the `lastUpdatedAt` value to use as `lastUpdatedAfter` in subsequent requests.
+
+When the poll response is empty, keep using the same timestamp until you get results.
 
 #### Implementation tips
 
@@ -120,8 +123,4 @@ Store the `lastUpdatedAt` value to use as `lastUpdatedAfter` in subsequent reque
 - Your storage solution must survive application restarts or crashes
 - If the response contains no data, reuse your current `lastUpdatedAfter` value
 - For first-time polling, use a historical date to fetch existing records
-
-#### Edge cases
-
-- **Initial setup**: Set `lastUpdatedAfter` to retrieve historical data as needed
 - **Empty responses**: Keep using the same timestamp until you get results

--- a/api/polling/README.md
+++ b/api/polling/README.md
@@ -123,4 +123,3 @@ When the poll response is empty, keep using the same timestamp until you get res
 - Your storage solution must survive application restarts or crashes
 - If the response contains no data, reuse your current `lastUpdatedAfter` value
 - For first-time polling, use a historical date to fetch existing records
-- **Empty responses**: Keep using the same timestamp until you get results


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-10478

### Scope
This PR ......
- adds response level `lastUpdateAt` to polling
- improve the polling usage documentation to make it clearer and more structured

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [x] Review your documentation
- [ ] Add labels `needs reviewing`
- [ ] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded and restructured the polling pattern guide for Tradecloud API v2.
  - Updated the title and description to reflect a clear, comprehensive implementation guide.
  - Introduced distinct sections including an overview and detailed implementation steps (Fetch, Process, Persist) with best practices and examples for better clarity and usability.
  - Enhanced instructions for fetching, processing, and persisting data with specific tips and example formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->