### PR TITLE
[TC-10869] Revert reopen

### DIFF
--- a/connectors/webhooks/order-events.md
+++ b/connectors/webhooks/order-events.md
@@ -78,13 +78,15 @@ The buyer can request an alternative delivery schedule or prices after confirmat
 The supplier can request an alternative delivery schedule or prices after confirmation. The buyer then approves or rejects the request.
 
 - **Requested**: The supplier requested to reopen confirmed order lines.
+- **Reverted**: The supplier reverted their reopen request.
 - **Approved or rejected**: The buyer approved or rejected the reopen request.
 
-| OrderEvent                               | Webhook Configuration                            |
-| ---------------------------------------- | ------------------------------------------------ |
-| `OrderLinesReopenRequestedBySupplier`    | Order lines reopen is requested by the supplier  |
-| `OrderLinesReopenRequestApprovedByBuyer` | Supplier reopen request is approved by the buyer |
-| `OrderLinesReopenRequestRejectedByBuyer` | Supplier reopen request is rejected by the buyer |
+| OrderEvent                                  | Webhook Configuration                            |
+| ------------------------------------------- | ------------------------------------------------ |
+| `OrderLinesReopenRequestedBySupplier`       | Order lines reopen is requested by the supplier  |
+| `OrderLinesReopenRequestRevertedBySupplier` | Supplier reopen request is reverted by the supplier |
+| `OrderLinesReopenRequestApprovedByBuyer`    | Supplier reopen request is approved by the buyer |
+| `OrderLinesReopenRequestRejectedByBuyer`    | Supplier reopen request is rejected by the buyer |
 
 ## Order reconfirmation request by buyer
 

--- a/order/buyer/reopen.md
+++ b/order/buyer/reopen.md
@@ -4,25 +4,42 @@ description: How to request the supplier to reopen an order line
 
 # Reopen an order
 
-If an order line is confirmed \(both parties agreed on the delivery of goods\) then the buyer should  request to `reopen` the line. Tradecloud will create a line level reopen workflow task which the supplier can approve, reject or propose an alternative.
+If an order line is **confirmed** (buyer and supplier agreed on delivery schedule, prices and related fields), the buyer can **reopen** it to propose different values. Tradecloud creates a line-level reopen workflow task that the supplier can **approve**, **reject** or **answer with a proposal**.
 
-When you reissue an order line with the  **requested** `delivery schedule` or `prices` **NOT** **equal** to the **confirmed** `delivery schedule` and `prices`, Tradecloud will automatically create a reopen workflow task for the supplier. When possible provide the buyer line `reason`field.
+## When a reopen request is created
 
-You may **update an reopen request** which is in progress, by updating an order line again.
+When you **reissue** an order line and the **requested** `delivery schedule`, `prices` and/or `charge lines` are **not equal** to the **confirmed** `delivery schedule`, `prices` and `charge lines`, Tradecloud automatically creates a reopen workflow task for the supplier.
+
+When possible, provide the buyer line `reason` field.
+
+## Update a reopen request that is in progress
+
+You may **change an open reopen request** by updating the order line again (same as creating a reopen: new requested values that still differ from confirmed).
 
 {% page-ref page="update.md" %}
 
-{% hint style="warning" %}
-This is a **request** to the supplier to reopen an already confirmed order line. 
+## Revert a reopen request
 
-The supplier has to **approve** the reopen request before Tradecloud accepts it.
+You can **withdraw** an open reopen request **without** waiting for the supplier to approve or reject it.
+
+Send an order update where the **requested** `delivery schedule`, `prices` and `charge lines` are **equal** to the **confirmed** `delivery schedule`, `prices` and `charge lines` — i.e. you align your request with what was already agreed before the reopen.
+
+In that case there is nothing left to negotiate: Tradecloud **reverts** the reopen workflow instead of keeping the line in negotiation. The line can return to process status `Confirmed` and the line-level [`inProgressStatus`](../status.md#line-in-progress-status) is cleared.
+
+This is **not** the same as the supplier rejecting the reopen; you are explicitly matching the last confirmed agreement.
+
+Webhook subscribers receive [`OrderLinesReopenRequestRevertedByBuyer`](../../../connectors/webhooks/order-events.md#order-reopen-request-by-buyer).
+
+{% hint style="warning" %}
+This is a **request** to the supplier to reopen an already confirmed order line.
+
+The supplier has to **approve** the reopen request before Tradecloud accepts a **change** that still differs from the confirmed values.
 {% endhint %}
 
 {% hint style="warning" %}
-You cannot reopen a `Completed` or `Cancelled` line
+You cannot reopen a `Completed` or `Cancelled` line.
 {% endhint %}
 
 {% hint style="info" %}
-An order line having process status `Confirmed` will become `InProgress`
+An order line with process status `Confirmed` becomes `InProgress` when a reopen request is open. See [Line process status](../status.md#line-process-status).
 {% endhint %}
-

--- a/order/buyer/update.md
+++ b/order/buyer/update.md
@@ -15,6 +15,7 @@ Most supplier ERP integrations do not have the capability to automatically proce
 * If an order line has order process status `Issued` or `In Progress` and it is updated, it will keep the same status.
 * If the line has status `Rejected` \(by supplier\) and it is reissued, it will become `In Progress`.
 * If the line has status `Confirmed` and it is reopened, it will become `In Progress`.
+* If the line is `In Progress` with an open buyer reopen request and your update makes the **requested** delivery schedule, prices and charge lines **equal** to the **confirmed** values again, Tradecloud **reverts** that reopen request — see [Revert a reopen request](reopen.md#revert-a-reopen-request).
 * In case of any other status like `Completed` or `Cancelled` the order update will be ignored.
 
 ### Endpoints

--- a/order/supplier/reopen.md
+++ b/order/supplier/reopen.md
@@ -4,29 +4,42 @@ description: How to request the buyer to reopen an order or line
 
 # Reopen an order
 
-{% hint style="warning" %}
-This feature is under development and API and documentation may change. 
-{% endhint %}
+If an order line is **confirmed** (buyer and supplier agreed on delivery schedule, prices and related fields), the supplier can **reopen** it to propose different values. Tradecloud creates a line-level reopen workflow task that the buyer can **approve** or **reject**.
 
-If an order line is confirmed \(both parties agreed on the delivery of goods\) then the supplier should  request  to `reopen` the line. Tradecloud will create a line level reopen workflow task which the buyer can approve or reject.
+## When a reopen request is created
 
-When the supplier sends an order response update with **responded** `delivery schedule` and `prices` **NOT** **equal** to the **confirmed** `delivery schedule` and `prices`, Tradecloud will automatically create line level reopen workflow task for the supplier. When possible provide the supplier line `reason`field.
+When you send an order response update and the **responded** `delivery schedule`, `prices` and/or `charge lines` are **not equal** to the **confirmed** `delivery schedule`, `prices` and `charge lines`, Tradecloud automatically creates a reopen workflow task for the **buyer**.
 
-You may **update an reopen request** which is in progress, by sending an order response update again.
+When possible, provide the supplier line `reason` field.
+
+## Update a reopen request that is in progress
+
+You may **change an open reopen request** by sending another order response update (new responded values that still differ from confirmed).
 
 {% page-ref page="send-order-response/" %}
 
-{% hint style="warning" %}
-This is a **request** to the buyer to reopen an already confirmed order line. 
+## Revert a reopen request
 
-The buyer has to **approve** the reopen request before Tradecloud accepts it.
+You can **withdraw** an open reopen request **without** waiting for the buyer to approve or reject it.
+
+Send an order response where the **responded** `delivery schedule`, `prices` and `charge lines` are **equal** to the **confirmed** `delivery schedule`, `prices` and `charge lines` — i.e. you align your response with what was already agreed before the reopen.
+
+In that case there is nothing left to negotiate: Tradecloud **reverts** the reopen workflow instead of keeping the line in negotiation. The line can return to process status `Confirmed` and the line-level [`inProgressStatus`](../status.md#line-in-progress-status) is cleared.
+
+This is **not** the same as the buyer rejecting the reopen; you are explicitly matching the last confirmed agreement.
+
+Webhook subscribers receive [`OrderLinesReopenRequestRevertedBySupplier`](../../../connectors/webhooks/order-events.md#order-reopen-request-by-supplier).
+
+{% hint style="warning" %}
+This is a **request** to the buyer to reopen an already confirmed order line.
+
+The buyer has to **approve** the reopen request before Tradecloud accepts a **change** that still differs from the confirmed values.
 {% endhint %}
 
 {% hint style="warning" %}
-You cannot reopen a `Completed` or `Cancelled` line
+You cannot reopen a `Completed` or `Cancelled` line.
 {% endhint %}
 
 {% hint style="info" %}
-An order line having process status `Confirmed` will become `InProgress`
+An order line with process status `Confirmed` becomes `InProgress` when a reopen request is open. See [Line process status](../status.md#line-process-status).
 {% endhint %}
-

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -38,7 +38,8 @@ The order line will become:
 
 - `Confirmed` if:
   - The `accepted` indicator is set, OR
-  - Responded delivery schedule and prices match the requested values
+  - Responded delivery schedule and prices match the requested values, OR
+  - The line has an open supplier reopen request and responded values match the **confirmed** values again (reverts the reopen) — see [Revert a reopen request](../reopen.md#revert-a-reopen-request)
 - `Rejected` if the `rejected` indicator is set
 - Stays `InProgress` if responded values still differ from requested values
 


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-10869

### Scope
This PR adds revert reopen documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new webhook event `OrderLinesReopenRequestRevertedBySupplier` for tracking supplier-initiated reopen request reversals.
  * Clarified reopen request workflow: buyers and suppliers can now propose different delivery schedules, prices, and charge lines.
  * Documented new capability: both buyers and suppliers can withdraw open reopen requests by reverting to confirmed values, automatically closing the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->