### PR TITLE
[TC-10978] Add header charge lines, and deprecate line charge lines

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "MD004": {
+    "style": "consistent"
+  },
+  "MD013": {
+    "line_length": 80
+  }
+}

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -77,6 +77,7 @@
       * [Attach a document to an order response](order/supplier/send-order-response/attach-document.md)
     * [Reopen an order](order/supplier/reopen.md)
   * [Order and line status](order/status.md)
+  * [Order line type](order/line-type.md)
 * [Shipments](shipment/README.md)
   * [Supplier shipment process](shipment/supplier/README.md)
     * [Send despatch advice](shipment/supplier/send-despatch-advice.md)

--- a/api/polling/echo.md
+++ b/api/polling/echo.md
@@ -7,31 +7,47 @@ description: >-
 
 ## The problem
 
-When your ERP system sends an order update or order response that results in an **open request** (e.g. a proposal, reopen or reschedule request), the other party must first approve or reject the change. Until that happens, the `lines.deliverySchedule`, `lines.prices` and `lines.chargeLines` fields keep returning the **previous** issued or confirmed values — not the values you just sent.
+When your ERP system sends an order update or order response that results in an
+**open request** (e.g. a proposal, reopen or reschedule request), the other
+party must first approve or reject the change. Until that happens, the
+`lines.deliverySchedule` and `lines.prices` fields keep returning the
+**previous** issued or confirmed values — not the values you just sent.
 
-On the next poll, your integration receives these old values. If your ERP system **does not distinguish between `requested` and `confirmed` fields**, it may overwrite the change it just submitted with the stale values from the poll response, effectively reverting your own update.
+On the next poll, your integration receives these old values. If your ERP system
+**does not distinguish between `requested` and `confirmed` fields**, it may
+overwrite the change it just submitted with the stale values from the poll
+response, effectively reverting your own update.
 
 ## The solution
 
-Skip processing a polled order line whenever it has an open request that originated from your side. Use the [`lines.status.processStatus`](../../order/status.md#line-process-status) or [`lines.status.inProgressStatus`](../../order/status.md#line-in-progress-status) fields to detect this.
+Skip processing a polled order line whenever it has an open request that
+originated from your side. Use the
+[`lines.status.processStatus`](../../order/status.md#line-process-status) or
+[`lines.status.inProgressStatus`](../../order/status.md#line-in-progress-status)
+fields to detect this.
 
 ### Option 1: Ignore all in-progress lines
 
-If your integration does not process open requests at all, ignore any order line where `lines.status.processStatus` is `InProgress`.
+If your integration does not process open requests at all, ignore any order line
+where `lines.status.processStatus` is `InProgress`.
 
 ### Option 2: Ignore only your own open requests
 
-If your integration does process incoming requests from the other party, only skip the lines where **you** are the requesting party:
+If your integration does process incoming requests from the other party, only
+skip the lines where **you** are the requesting party:
 
-**Buyer integration** — ignore the response update when `lines.status.inProgressStatus` is one of:
+**Buyer integration** — ignore the response update when
+`lines.status.inProgressStatus` is one of:
 
-* `OpenBuyerReopenRequest`
-* `OpenBuyerReconfirmationRequest`
+- `OpenBuyerReopenRequest`
+- `OpenBuyerReconfirmationRequest`
 
-**Supplier integration** — ignore the order update when `lines.status.inProgressStatus` is one of:
+**Supplier integration** — ignore the order update when
+`lines.status.inProgressStatus` is one of:
 
-* `OpenSupplierProposal`
-* `OpenSupplierReopenRequest`
-* `OpenSupplierShipmentRescheduleRequest`
+- `OpenSupplierProposal`
+- `OpenSupplierReopenRequest`
+- `OpenSupplierShipmentRescheduleRequest`
 
-See [Line in Progress status](../../order/status.md#line-in-progress-status) for the complete list of in-progress status values.
+See [Line in Progress status](../../order/status.md#line-in-progress-status) for
+the complete list of in-progress status values.

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -4,22 +4,27 @@ description: How to issue a new purchase order as a buyer
 
 # Issue a new order
 
-As a buyer, you can send either a **new order** or an [**updated order**](../update.md) to your supplier.
+As a buyer, you can send either a **new order** or an [**updated
+order**](../update.md) to your supplier.
 
 ## Order process
 
 {% hint style="info" %}
-New order lines will have order process status `Issued` and logistics status `Open`
+New order lines will have order process status `Issued` and logistics status
+`Open`
 {% endhint %}
 
 ## Sending methods
 
 ### Delivery schedule options
 
-Choose the appropriate endpoint based on your ERP system's delivery handling capabilities:
+Choose the appropriate endpoint based on your ERP system's delivery handling
+capabilities:
 
-- Use the [Send order](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderByBuyerRoute) endpoint when your ERP system supports delivery schedules natively
-- Use the [Send single delivery order](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendSingleDeliveryByBuyerRoute) endpoint for single scheduled delivery per order line
+- Use the [Send order](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderByBuyerRoute)
+  endpoint when your ERP system supports delivery schedules natively
+- Use the [Send single delivery order](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendSingleDeliveryByBuyerRoute)
+  endpoint for single scheduled delivery per order line
 
 For more details on choosing between delivery schedule options:
 
@@ -31,87 +36,136 @@ When sending an order the provided supplier account number will be verified.
 
 ## Order
 
-* `companyId`: the optional Tradecloud company identifier. You only have to provide a companyId when your integration user account has authorization for multiple companies.
-* `buyerParty`: the optional legal entity that purchases the goods or services. See [Company party](#company-party).
-* `buyerAccountingParty`: the optional legal entity that receives and handles the invoice. The supplier must send the invoice to the buyer accounting party when specified. See [Company party](#company-party).
-* `supplierAccountNumber`: the supplier account number as known in your ERP system.
+- `companyId`: the optional Tradecloud company identifier. You only have to
+  provide a companyId when your integration user account has authorization for
+  multiple companies.
+- `buyerParty`: the optional legal entity that purchases the goods or services.
+  See [Company party](#company-party).
+- `buyerAccountingParty`: the optional legal entity that receives and handles
+  the invoice. The supplier must send the invoice to the buyer accounting party
+  when specified. See [Company party](#company-party).
+- `supplierAccountNumber`: the supplier account number as known in your ERP
+  system.
 
 {% hint style="warning" %}
-The `supplierAccountNumber` must be set in the Tradecloud connection in the portal, after the connection request has been accepted by the other party.
+The `supplierAccountNumber` must be set in the Tradecloud connection in the
+portal, after the connection request has been accepted by the other party.
 {% endhint %}
 
-* `supplierParty`: the optional legal entity that sells the goods or services. See [Company party](#company-party).
-* `purchaseOrderNumber`: the purchase order number as known in your ERP system.
+- `supplierParty`: the optional legal entity that sells the goods or services.
+  See [Company party](#company-party).
+- `purchaseOrderNumber`: the purchase order number as known in your ERP system.
 
 {% hint style="warning" %}
 The `purchaseOrderNumber` must not contain whitespace characters.
 {% endhint %}
 
-* `destination`: the delivery destination of this order as known in your ERP system
-* `contact.email`: the buyer employee responsible for this order. The user with this email address should be active in Tradecloud.
-* `supplierContact.email`: if known, the supplier employee responsible for this order. The user with this email address should be active in Tradecloud.
+- `destination`: the delivery destination of this order as known in your ERP
+  system
+- `contact.email`: the buyer employee responsible for this order. The user with
+  this email address should be active in Tradecloud.
+- `supplierContact.email`: if known, the supplier employee responsible for this
+  order. The user with this email address should be active in Tradecloud.
 
 {% hint style="warning" %}
-`id`, `supplierAccountNumber`, `purchaseOrderNumber`, `destination.code` and `contact.email` should be unique within your company and never change. Never renumber or re-use identifiers, numbers or code's.
+`id`, `supplierAccountNumber`, `purchaseOrderNumber`, `destination.code` and
+`contact.email` should be unique within your company and never change. Never
+renumber or re-use identifiers, numbers or code's.
 {% endhint %}
 
 ### Company party
 
 The optional buyer, buyer accounting or supplier company party:
 
-* `id`: the optional identifier for the party, for example a GLN.
-* `idScheme`: the optional scheme, providing context to the identifier. Eg. `"KvK"`, `"GLN"`, etc.
-* `names`: the legal names of the party. It is recommended to provide at least one name.
-* `addressLines`: the location address lines of the party. It is recommended to provide at least one address line.
-* `postalCode`: the location postal code of the party. Provide when `addressLines` are provided.
-* `city`: the location city of the party. Provide when `addressLines` are provided.
-* `countryCodeIso2` the ISO 3166-1 alpha-2 country code of the party. Provide when `addressLines` are provided.
-* `countryName` the optional country name of the party.
+- `id`: the optional identifier for the party, for example a GLN.
+- `idScheme`: the optional scheme, providing context to the identifier. Eg.
+  `"KvK"`, `"GLN"`, etc.
+- `names`: the legal names of the party. It is recommended to provide at least
+  one name.
+- `addressLines`: the location address lines of the party. It is recommended to
+  provide at least one address line.
+- `postalCode`: the location postal code of the party. Provide when
+  `addressLines` are provided.
+- `city`: the location city of the party. Provide when `addressLines` are
+  provided.
+- `countryCodeIso2` the ISO 3166-1 alpha-2 country code of the party. Provide
+  when `addressLines` are provided.
+- `countryName` the optional country name of the party.
 
 ### Other order fields
 
-* `description`: a free format additional description of this order
-* `terms`: the order terms as agreed with your supplier
-* `indicators`: various order level indicators, see:
+- `description`: a free format additional description of this order
+- `terms`: the order terms as agreed with your supplier
+- `indicators`: various order level indicators, see:
 
 {% page-ref page="indicators.md" %}
 
-* `properties`: are key-value based custom fields. You can user as many as needed, but too many will clutter the portal. Use `\n` for a new line in the value.
-* `notes`: are simple custom fields. You can user as many as needed, but too many will clutter the portal. Use `\n` for a new line.
-* `labels`: value-added services labels on order level. Please note the practicable number of labels is dependent on the supplier.
-* `documents`: contain meta data and link of attached documents. The total number of documents is limited to 100 documents per order header. See:
+- `properties`: are key-value based custom fields. You can user as many as
+  needed, but too many will clutter the portal. Use `\n` for a new line in the
+  value.
+- `notes`: are simple custom fields. You can user as many as needed, but too
+  many will clutter the portal. Use `\n` for a new line.
+- `labels`: value-added services labels on order level. Please note the
+  practicable number of labels is dependent on the supplier.
+- `documents`: contain meta data and link of attached documents. The total
+  number of documents is limited to 100 documents per order header. See:
 
 {% page-ref page="attach-document.md" %}
 
-* `orderType`: the order type, one of `Purchase`, `Forecast` or `RFQ`. Default `Purchase`.
+- `orderType`: the order type, one of `Purchase`, `Forecast` or `RFQ`. Default
+  `Purchase`.
 
 ## Lines
 
-`lines`: a purchase order contains one or multiple lines. The total number of lines is limited to 500 lines per order. It is structured as a JSON element in the `lines` JSON array.
+`lines`: a purchase order contains one or multiple lines. The total number of
+lines is limited to 500 lines per order. It is structured as a JSON element in
+the `lines` JSON array.
 
-* `position`: the required line position identifier within the purchase order
-* `row`: the optional row label for this position. Only use a row when there is a distinction between position and row in your ERP system. Do NOT use row as identifier.
+- `position`: the required line position identifier within the purchase order
+- `row`: the optional row label for this position. Only use a row when there is
+  a distinction between position and row in your ERP system. Do NOT use row as
+  identifier.
 
 {% hint style="warning" %}
-`lines.position` should be unique within the order and never change. Never renumber or re-use `position` numbers.
+`lines.position` should be unique within the order and never change. Never
+renumber or re-use `position` numbers.
+{% endhint %}
+
+### Line type and charge reason code
+
+- `lineType`: classifies the line as `Item`, `Service`, or `Charge`. When
+  omitted, the line is treated as `Item` (backward compatible).
+- `chargeReasonCode`: optional — UNCL7161 charge or allowance reason code on the
+  line (for example `FC` for freight). Typically used together with `lineType`
+  `Charge`. See the [UNCL7161 code list](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/).
+
+{% hint style="info" %}
+See [Order line type](../../line-type.md) for a full overview (introduced with
+[TC-10879](https://tradecloud.atlassian.net/browse/TC-10879)).
 {% endhint %}
 
 ### Item
 
 `lines.item`: the item \(or article, goods\) to be delivered
 
-* `number`: the item code or number as known in your ERP
-* `revision`: the revision \(or version\) of this item number
-* `name`: the item short name
-* `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`
-* `supplierItemNumber`: the item code or number as known at the supplier. Required in case of wholesale suppliers.
+- `number`: the item code or number as known in your ERP
+- `revision`: the revision \(or version\) of this item number
+- `name`: the item short name
+- `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a
+  typical example is `PCE`
+- `supplierItemNumber`: the item code or number as known at the supplier.
+  Required in case of wholesale suppliers.
 
 {% hint style="warning" %}
-`item.number` and `item.supplierItemNumber` are optional and may be left empty, for example in case of service or RFQ orders.
+`item.number` and `item.supplierItemNumber` are optional and may be left empty,
+for example in case of service or RFQ orders.
 
-Leaving the `item.number` and `item.supplierItemNumber` both empty is not recommended for integrated suppliers, as the supplier might reject the order line.
+Leaving the `item.number` and `item.supplierItemNumber` both empty is not
+recommended for integrated suppliers, as the supplier might reject the order
+line.
 
-`item.number` should be unique within the buyer's company and never change. Never renumber or re-use `item.number`s for a different item.
+`item.number` should be unique within the buyer's company and never change.
+Never renumber or re-use `item.number`s for a different item.
 {% endhint %}
 
 ### Item details
@@ -120,79 +174,123 @@ Leaving the `item.number` and `item.supplierItemNumber` both empty is not recomm
 
 {% hint style="info" %}
 The buyer may send item details to inform the supplier about part information.  
-The supplier may check, change and add item details if they are not correct or incomplete.  
-The webhook `orderEvent.lines.itemDetails.mergedItemDetails` will contain the merged original item details added by the buyer merged with the changed or added item details by the supplier.
+The supplier may check, change and add item details if they are not correct or
+incomplete.
+The webhook `orderEvent.lines.itemDetails.mergedItemDetails` will contain the
+merged original item details added by the buyer merged with the changed or added
+item details by the supplier.
 {% endhint %}
 
-* `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture, production, or growth where an article or product comes from.
-* `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the requirements both of the Common Customs Tariff and of the EU's external trade statistics.
-* `netWeight`: Net weight of one item.
-* `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
-* `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that identify dangerous goods, hazardous substances and articles in the framework of international transport.
-* `serialNumber`: is an unique identifier assigned incrementally or sequentially to an item, to uniquely identify it.
-* `batchNumber`: is an identification number assigned to a particular quantity or lot of material from a single manufacturer
+- `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture,
+  production, or growth where an article or product comes from.
+- `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the
+  requirements both of the Common Customs Tariff and of the EU's external trade
+  statistics.
+- `netWeight`: Net weight of one item.
+- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
+  identify dangerous goods, hazardous substances and articles in the framework
+  of international transport.
+- `serialNumber`: is an unique identifier assigned incrementally or sequentially
+  to an item, to uniquely identify it.
+- `batchNumber`: is an identification number assigned to a particular quantity
+  or lot of material from a single manufacturer
 
 ### Requested planned delivery schedule
 
-Use the `lines.deliverySchedule` field when your ERP system supports a delivery schedule natively.
+Use the `lines.deliverySchedule` field when your ERP system supports a delivery
+schedule natively.
 
-Or use the `lines.scheduledDelivery` field when using single delivery per order line.
+Or use the `lines.scheduledDelivery` field when using single delivery per order
+line.
 
-Please see this page to choose between the delivery schedule or single delivery per order line:
+Please see this page to choose between the delivery schedule or single delivery
+per order line:
 
 {% page-ref page="delivery-schedule.md" %}
 
 ### Requested prices
 
-`lines.prices`: the requested price. Advised is to provide only `netPrice` for its simplicity, used by most buyers, or alternatively `grossPrice` together with `discountPercentage`.
+`lines.prices`: the requested price. Advised is to provide only `netPrice` for
+its simplicity, used by most buyers, or alternatively `grossPrice` together with
+`discountPercentage`.
 
-* `grossPrice`: the gross price. Use together with `discountPercentage`.
-* `discountPercentage`: the discount percentage. Use together with `grossPrice`.
-* `netPrice`: the net price.
-  * `priceInTransactionCurrency`: at least provide a price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
-  * `priceInBaseCurrency`: provide a price in your base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `priceUnitOfMeasureIso`: the price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-* `priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
+- `grossPrice`: the gross price. Use together with `discountPercentage`.
+- `discountPercentage`: the discount percentage. Use together with `grossPrice`.
+- `netPrice`: the net price.
+  - `priceInTransactionCurrency`: at least provide a price in the transaction
+    currency of the supplier, like `CNY` in China.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`, `USD` and `CNY`.
+  - `priceInBaseCurrency`: provide a price in your base currency, like `EUR` in
+    the EU.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`.
+- `priceUnitOfMeasureIso`: the price unit according to ISO 80000-1. The purchase
+  unit and price unit may be different.
+- `priceUnitQuantity`: the item quantity at which the price applies. Typically
+  this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
 
 ### Requested charge lines
 
-`lines.chargeLines`: the requested additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
+{% hint style="warning" %}
+**Deprecated.** Charge lines (`chargeLines`) are deprecated. Prefer `lineType`
+`Charge` and line-level pricing — see [Order line type](../../line-type.md). The
+following is retained for existing integrations only.
+{% endhint %}
 
-* `position`: the position used to identify a charge line.
-* `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
-* `chargeDescription`: a mandatory free text description, like "Transport costs".
-* `quantity`: the mandatory quantity of this charge line.
-* `price`: the mandatory price of this charge line.
-  * `priceInTransactionCurrency`: the mandatory price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
-  * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1 which applies to the charge line price.
+`lines.chargeLines`: the requested additional cost lines of an order line,
+independent of the order line prices, like transport, packing, administration,
+inspection and certification costs.
+
+- `position`: the position used to identify a charge line.
+- `chargeTypeCode`: the mandatory charge reason code according to
+  [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
+- `chargeDescription`: a mandatory free text description, like "Transport
+  costs".
+- `quantity`: the mandatory quantity of this charge line.
+- `price`: the mandatory price of this charge line.
+  - `priceInTransactionCurrency`: the mandatory price in the transaction
+    currency of the supplier, like `CNY` in China.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`, `USD` and `CNY`.
+  - `priceInBaseCurrency`: the optional price in your base currency, like `EUR`
+    in the EU.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`.
+- `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1
+  which applies to the charge line price.
 
 {% hint style="warning" %}
-The single delivery variant, where charge lines are spread over multiple order lines having the same item, prices and terms, and each only one charge line, is not supported. Send a support request if you need it.
+**Deprecated.** The single delivery variant, where charge lines are spread over
+multiple order lines having the same item, prices and terms, and each only one
+charge line, is not supported. Send a support request if you need it.
 {% endhint %}
 
 ### Other line fields
 
-* `description`: a free format additional description of this line
-* `terms`: the line terms as agreed with your supplier
-  * `contractNumber`: the agreed framework contract number
-  * `contractPosition`: the related position within the framework contract
-* `projectNumber`: Your project number reference
-* `productionNumber`:  Your production number reference
-* `salesOrderNumber`:  Your sales order reference \(not be confused with the supplier sales order number\)
-* `indicators`: various line level indicators, see:
+- `description`: a free format additional description of this line
+- `terms`: the line terms as agreed with your supplier
+  - `contractNumber`: the agreed framework contract number
+  - `contractPosition`: the related position within the framework contract
+- `projectNumber`: Your project number reference
+- `productionNumber`:  Your production number reference
+- `salesOrderNumber`: Your sales order reference \(not be confused with the
+  supplier sales order number\)
+- `indicators`: various line level indicators, see:
 
 {% page-ref page="indicators.md" %}
 
-When a line has no goods to be delivered, for example a service, fee or text line:
+When a line has no goods to be delivered, for example a service, fee or text
+line:
 
 {% page-ref page="no-delivery-expected.md" %}
 
@@ -200,19 +298,30 @@ When your order process requires the buyer to always approve every line:
 
 {% page-ref page="propose-when-accepted.md" %}
 
-* `properties`: are key-value based custom fields. You can use as many as needed, but too many will clutter the portal.  Use `\n` for a new line in the value.
-* `documents`: contain attached documents. The total number of documents is limited to 100 documents per order line. See:
+- `properties`: are key-value based custom fields. You can use as many as
+  needed, but too many will clutter the portal. Use `\n` for a new line in the
+  value.
+- `documents`: contain attached documents. The total number of documents is
+  limited to 100 documents per order line. See:
 
 {% page-ref page="attach-document.md" %}
 
-* `notes`: are simple custom fields.You can use as many as needed, but too many will clutter the portal. Use `\n` for a new line.
-* `labels`: value-added services labels on line level. Please note the practicable number of labels is dependent on the supplier.
+- `notes`: are simple custom fields.You can use as many as needed, but too many
+  will clutter the portal. Use `\n` for a new line.
+- `labels`: value-added services labels on line level. Please note the
+  practicable number of labels is dependent on the supplier.
 
 ## New order meta data
 
-* `erpIssueDateTime`: Date and time the order was originally issued in your ERP system. `DateTime` has ISO 8601 local date/time format `yyyy-MM-ddThh:mm:ss`. See also [Standards](../../api/standards.md).
-* `erpIssuedBy`: the user email or user name as known in your ERP system who issued this order
+- `erpIssueDateTime`: Date and time the order was originally issued in your ERP
+  system. `DateTime` has ISO 8601 local date/time format `yyyy-MM-ddThh:mm:ss`.
+  See also [Standards](../../api/standards.md).
+- `erpIssuedBy`: the user email or user name as known in your ERP system who
+  issued this order
 
 ## Response
 
-When the `/api-connector/order` API method returns HTTP status code 200, the order was successfully queued for processing by Tradecloud. Processing takes usually less then a second, after which the order is available in the portal and is forwarded to the supplier ERP integration.
+When the `/api-connector/order` API method returns HTTP status code 200, the
+order was successfully queued for processing by Tradecloud. Processing takes
+usually less then a second, after which the order is available in the portal and
+is forwarded to the supplier ERP integration.

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -137,7 +137,7 @@ renumber or re-use `position` numbers.
 
 - `lineType`: classifies the line as `Item`, `Service`, or `Charge`. When
   omitted, the line is treated as `Item` (backward compatible).
-- `chargeReasonCode`: optional — UNCL7161 charge or allowance reason code on the
+- `chargeReasonCode`: optional UNCL7161 charge or allowance reason code on the
   line (for example `FC` for freight). Typically used together with `lineType`
   `Charge`. See the [UNCL7161 code list](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/).
 

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -122,6 +122,8 @@ lines is limited to 500 lines per order. It is structured as a JSON element in
 the `lines` JSON array.
 
 - `position`: the required line position identifier within the purchase order
+- `originalPosition`: optional position referencing the original order line when
+  the line has been split (single delivery endpoints only)
 - `row`: the optional row label for this position. Only use a row when there is
   a distinction between position and row in your ERP system. Do NOT use row as
   identifier.
@@ -140,8 +142,7 @@ renumber or re-use `position` numbers.
   `Charge`. See the [UNCL7161 code list](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/).
 
 {% hint style="info" %}
-See [Order line type](../../line-type.md) for a full overview (introduced with
-[TC-10879](https://tradecloud.atlassian.net/browse/TC-10879)).
+See [Order line type](../../line-type.md) for a full overview.
 {% endhint %}
 
 ### Item
@@ -238,41 +239,8 @@ its simplicity, used by most buyers, or alternatively `grossPrice` together with
 ### Requested charge lines
 
 {% hint style="warning" %}
-**Deprecated.** Charge lines (`chargeLines`) are deprecated. Prefer `lineType`
-`Charge` and line-level pricing — see [Order line type](../../line-type.md). The
-following is retained for existing integrations only.
-{% endhint %}
-
-`lines.chargeLines`: the requested additional cost lines of an order line,
-independent of the order line prices, like transport, packing, administration,
-inspection and certification costs.
-
-- `position`: the position used to identify a charge line.
-- `chargeTypeCode`: the mandatory charge reason code according to
-  [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
-- `chargeDescription`: a mandatory free text description, like "Transport
-  costs".
-- `quantity`: the mandatory quantity of this charge line.
-- `price`: the mandatory price of this charge line.
-  - `priceInTransactionCurrency`: the mandatory price in the transaction
-    currency of the supplier, like `CNY` in China.
-    - `value`: the price value has a decimal `1234.56` format with any number
-      of digits.
-    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
-      `EUR`, `USD` and `CNY`.
-  - `priceInBaseCurrency`: the optional price in your base currency, like `EUR`
-    in the EU.
-    - `value`: the price value has a decimal `1234.56` format with any number
-      of digits.
-    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
-      `EUR`.
-- `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1
-  which applies to the charge line price.
-
-{% hint style="warning" %}
-**Deprecated.** The single delivery variant, where charge lines are spread over
-multiple order lines having the same item, prices and terms, and each only one
-charge line, is not supported. Send a support request if you need it.
+**Deprecated.** Charge lines (`chargeLines`) are deprecated. Superseded by `lineType`
+`Charge` and line-level pricing, see [Order line type](../../line-type.md).
 {% endhint %}
 
 ### Other line fields
@@ -282,7 +250,7 @@ charge line, is not supported. Send a support request if you need it.
   - `contractNumber`: the agreed framework contract number
   - `contractPosition`: the related position within the framework contract
 - `projectNumber`: Your project number reference
-- `productionNumber`:  Your production number reference
+- `productionNumber`: Your production number reference
 - `salesOrderNumber`: Your sales order reference \(not be confused with the
   supplier sales order number\)
 - `indicators`: various line level indicators, see:

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -100,10 +100,10 @@ The optional buyer, buyer accounting or supplier company party:
 
 {% page-ref page="indicators.md" %}
 
-- `properties`: are key-value based custom fields. You can user as many as
+- `properties`: are key-value based custom fields. You can use as many as
   needed, but too many will clutter the portal. Use `\n` for a new line in the
   value.
-- `notes`: are simple custom fields. You can user as many as needed, but too
+- `notes`: are simple custom fields. You can use as many as needed, but too
   many will clutter the portal. Use `\n` for a new line.
 - `labels`: value-added services labels on order level. Please note the
   practicable number of labels is dependent on the supplier.
@@ -274,7 +274,7 @@ When your order process requires the buyer to always approve every line:
 
 {% page-ref page="attach-document.md" %}
 
-- `notes`: are simple custom fields.You can use as many as needed, but too many
+- `notes`: are simple custom fields. You can use as many as needed, but too many
   will clutter the portal. Use `\n` for a new line.
 - `labels`: value-added services labels on line level. Please note the
   practicable number of labels is dependent on the supplier.
@@ -291,5 +291,5 @@ When your order process requires the buyer to always approve every line:
 
 When the `/api-connector/order` API method returns HTTP status code 200, the
 order was successfully queued for processing by Tradecloud. Processing takes
-usually less then a second, after which the order is available in the portal and
+usually less than a second, after which the order is available in the portal and
 is forwarded to the supplier ERP integration.

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -87,7 +87,7 @@ The order header contains:
   status](../../status.md#order-logistics-status).
 - `version`: the Tradecloud order version number
 - `eventDates`: some key order event date/times
-- `meta`: meta information, including source and trace info, about this messsage
+- `meta`: meta information, including source and trace info, about this message
 - `lastUpdatedAt`: is the latest date time the order has been changed, useful
   for polling orders.
 
@@ -106,10 +106,10 @@ The order header contains:
 - `companyId`: the supplier's Tradecloud company identifier.
 - `buyerAccountNumber`: your account number as known in the supplier's ERP
   system.
-- `description`: a free format additional description of this order by the
+- `description`: a free-format additional description of this order by the
   supplier.
 - `contact`: the supplier employee responsible for this order.
-- `properties`: are key-value based custom fields, added by the supplier.
+- `properties`: are key-value-based custom fields, added by the supplier.
 - `notes`: are simple custom fields, added by the supplier.
 - `documents`: contain meta data and link of attached documents by the supplier.
 
@@ -142,7 +142,7 @@ The order status is the aggregation of all the lines statuses. See
 - `indicators.deliveryOverdue` is true when the order line is overdue.
 - `status.processStatus`: the order line's [Line process
   status](../../status.md#line-process-status).
-- `status.inProgressStatus` the order line's [Line in progress
+- `status.inProgressStatus`: the order line's [Line in progress
   status](../../status.md#line-in-progress-status).
 - `status.logisticsStatus`: the order line's [Line logistics
   status](../../status.md#line-logistics-status).
@@ -166,11 +166,11 @@ new order](../issue/#lines)
 - `salesOrderNumber`: the sales order number as known in the supplier's ERP
   system
 - `salesOrderPosition`: the position within the supplier's sales order
-- `description`: a free format additional description of this line by the
+- `description`: a free-format additional description of this line by the
   supplier
 - `requests`: the supplier can request different delivery schedule and prices,
   see below
-- `properties`: are key-value based custom fields, added by the supplier
+- `properties`: are key-value-based custom fields, added by the supplier
 - `notes`: are simple custom fields, added by the supplier
 - `documents`: contain meta data, objectId or url, of attached documents by the
   supplier.

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -322,8 +322,8 @@ process, in progress and logistics status values.
 ### Charge lines
 
 {% hint style="warning" %}
-**Deprecated.** Charge lines (`chargeLines`) are deprecated. The following is
-retained for existing integrations only.
+**Deprecated.** Charge lines (`chargeLines`) are deprecated. Superseded by `lineType`
+`Charge` and line-level pricing, see [Order line type](../../line-type.md).
 {% endhint %}
 
 ### Item details
@@ -355,7 +355,6 @@ buyer merged with the changed or added item details by the supplier.
 
 - `messageId`: The Tradecloud identifier of this message
 - `source`: Includes meta information about the source of this message:
-
   - `traceId`: The Tradecloud trace identifier of this message. All related
     messages in a flow will have the same traceId
   - `userId`: The Tradecloud user identifier which triggered the first message

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -125,6 +125,8 @@ The order status is the aggregation of all the lines statuses. See
 `lines` contains one or more order lines:
 
 - `id`: the Tradecloud line identifier
+- `lineType`: one of `Item`, `Service`, or `Charge`. See [Order line type](../../line-type.md)
+- `chargeReasonCode`: optional UNCL7161 code when the buyer set a charge
 - `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
 - `supplierLine`: the supplier part of the order line, see [Supplier
   line](#supplier-line).

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -4,7 +4,8 @@ description: How to receive a purchase order response sent by the supplier
 
 # Receive an order response
 
-Tradecloud sends purchase order responses to buyers when order events are triggered.
+Tradecloud sends purchase order responses to buyers when order events are
+triggered.
 
 ## Receiving methods
 
@@ -38,9 +39,11 @@ If you're using single delivery format, please see:
 
 ### Using the webhook API
 
-See the [Webhook setup guide](../../../connectors/webhooks/webhook-setup.md) for instructions on how to configure the webhook API.
+See the [Webhook setup guide](../../../connectors/webhooks/webhook-setup.md) for
+instructions on how to configure the webhook API.
 
-Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost)
+endpoint.
 
 The webhook body contains:
 
@@ -50,234 +53,314 @@ The webhook body contains:
 
 ### Using the polling API
 
-See the [Polling setup guide](../../../api/polling/README.md) for instructions on how to configure polling.
+See the [Polling setup guide](../../../api/polling/README.md) for instructions
+on how to configure polling.
 
-Use the [POST poll orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute) endpoint.
+Use the [POST poll orders](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute)
+endpoint.
 
 The polling response body contains:
 
 - `data`: Contains the actual orders in its current state
 - `total`: The total no. of matching orders, regardless of paging.
-- `lastUpdatedAt`: Store the `lastUpdatedAt` value to use as `lastUpdatedAfter` in subsequent requests.
+- `lastUpdatedAt`: Store the `lastUpdatedAt` value to use as `lastUpdatedAfter`
+  in subsequent requests.
 
 ## Response structure
 
-This section assumes you're using delivery schedules with either the `orderEvent` webhook API or the `order` polling API.
+This section assumes you're using delivery schedules with either the
+`orderEvent` webhook API or the `order` polling API.
 
 ### Order header
 
 The order header contains:
 
-* `id` (in `order`) or `orderId` (in `orderEvent`): Tradecloud order identifier
-* `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order)
-* `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
-* `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines [Order process status](../../status.md#order-process-status).
-* `status.logisticsStatus`: is the aggregate of all lines [Order logistics status](../../status.md#order-logistics-status).
-* `version`: the Tradecloud order version number
-* `eventDates`: some key order event date/times
-* `meta`: meta information, including source and trace info, about this messsage
-* `lastUpdatedAt`: is the latest date time the order has been changed, useful for polling orders.
+- `id` (in `order`) or `orderId` (in `orderEvent`): Tradecloud order
+  identifier
+- `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order)
+- `supplierOrder`: the supplier part of the order, see
+  [Supplier order](#supplier-order)
+- `indicators.deliveryOverdue` is true when at least one order line is overdue.
+- `status.processStatus`: is the aggregate of all lines [Order process
+  status](../../status.md#order-process-status).
+- `status.logisticsStatus`: is the aggregate of all lines [Order logistics
+  status](../../status.md#order-logistics-status).
+- `version`: the Tradecloud order version number
+- `eventDates`: some key order event date/times
+- `meta`: meta information, including source and trace info, about this messsage
+- `lastUpdatedAt`: is the latest date time the order has been changed, useful
+  for polling orders.
 
 ### Buyer order
 
-`buyerOrder` is mostly an echo of your order fields as explained in [Issue a new order](../issue/#order-body-json-objects)
+`buyerOrder` is mostly an echo of your order fields as explained in
+[Issue a new order](../issue/#order-body-json-objects)
 
-* `supplierAccountNumber`: the supplier account number as known in your ERP system
+- `supplierAccountNumber`: the supplier account number as known in your ERP
+  system
 
 ### Supplier order
 
 `supplierOrder` contains the supplier order fields:
 
-* `companyId`: the supplier's Tradecloud company identifier.
-* `buyerAccountNumber`: your account number as known in the supplier's ERP system.
-* `description`: a free format additional description of this order by the supplier.
-* `contact`: the supplier employee responsible for this order.
-* `properties`: are key-value based custom fields, added by the supplier.
-* `notes`: are simple custom fields, added by the supplier.
-* `documents`: contain meta data and link of attached documents by the supplier.
+- `companyId`: the supplier's Tradecloud company identifier.
+- `buyerAccountNumber`: your account number as known in the supplier's ERP
+  system.
+- `description`: a free format additional description of this order by the
+  supplier.
+- `contact`: the supplier employee responsible for this order.
+- `properties`: are key-value based custom fields, added by the supplier.
+- `notes`: are simple custom fields, added by the supplier.
+- `documents`: contain meta data and link of attached documents by the supplier.
 
 {% page-ref page="download-document.md" %}
 
 ### Order status
 
-The order status is the aggregation of all the lines statuses. See [Order status](../../status.md#order-status) for the complete list of values.
+The order status is the aggregation of all the lines statuses. See
+[Order status](../../status.md#order-status) for the complete list of values.
 
 ## `orderEvent` or `order` lines
 
 `lines` contains one or more order lines:
 
-* `id`: the Tradecloud line identifier
-* `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
-* `supplierLine`: the supplier part of the order line, see [Supplier line](#supplier-line).
-* `confirmedLine`: the order line as agreed between buyer and supplier, see [Confirmed line](#confirmed-line).
-* `deliverySchedule`: the current aggregated delivery schedule, see [Delivery schedule](#delivery-schedule).
-* `deliveryScheduleIncludingRequests`: the current aggregated delivery schedule including requests, see [Delivery schedule](#delivery-schedule).
-* `prices`: the current prices, see [Prices](#prices) below.
-* `pricesIncludingRequests`: the current prices, including any open supplier or buyer requests, see [Prices](#prices).
-* `indicators.deliveryOverdue` is true when the order line is overdue.
-* `status.processStatus`: the order line's [Line process status](../../status.md#line-process-status).
-* `status.inProgressStatus` the order line's [Line in progress status](../../status.md#line-in-progress-status).
-* `status.logisticsStatus`: the order line's [Line logistics status](../../status.md#line-logistics-status).
-* `eventDates`: some key line event date/times
-* `mergedItemDetails`: detailed part information provided by both buyer and supplier, see [Item details](#item-details).
-* `lastUpdatedAt`: is the latest date time the order line has been changed, useful for polling.
+- `id`: the Tradecloud line identifier
+- `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
+- `supplierLine`: the supplier part of the order line, see [Supplier
+  line](#supplier-line).
+- `confirmedLine`: the order line as agreed between buyer and supplier, see
+  [Confirmed line](#confirmed-line).
+- `deliverySchedule`: the current aggregated delivery schedule, see
+  [Delivery schedule](#delivery-schedule).
+- `deliveryScheduleIncludingRequests`: the current aggregated delivery schedule
+  including requests, see [Delivery schedule](#delivery-schedule).
+- `prices`: the current prices, see [Prices](#prices) below.
+- `pricesIncludingRequests`: the current prices, including any open supplier or
+  buyer requests, see [Prices](#prices).
+- `indicators.deliveryOverdue` is true when the order line is overdue.
+- `status.processStatus`: the order line's [Line process
+  status](../../status.md#line-process-status).
+- `status.inProgressStatus` the order line's [Line in progress
+  status](../../status.md#line-in-progress-status).
+- `status.logisticsStatus`: the order line's [Line logistics
+  status](../../status.md#line-logistics-status).
+- `eventDates`: some key line event date/times
+- `mergedItemDetails`: detailed part information provided by both buyer and
+  supplier, see [Item details](#item-details).
+- `lastUpdatedAt`: is the latest date time the order line has been changed,
+  useful for polling.
 
 ### Buyer line
 
-`lines.buyerLine` is an echo of your order line fields as explained in [Issue a new order](../issue/#lines)
+`lines.buyerLine` is an echo of your order line fields as explained in [Issue a
+new order](../issue/#lines)
 
-* `position`: the line position within the purchase order
+- `position`: the line position within the purchase order
 
 ### Supplier line
 
 `lines.supplierLine` contains the supplier order line fields:
 
-* `salesOrderNumber`: the sales order number as known in the supplier's ERP system
-* `salesOrderPosition`: the position within the supplier's sales order
-* `description`: a free format additional description of this line by the supplier
-* `requests`: the supplier can request different delivery schedule, prices and charge lines, see below
-* `properties`: are key-value based custom fields, added by the supplier
-* `notes`: are simple custom fields, added by the supplier
-* `documents`: contain meta data, objectId or url, of attached documents by the supplier.
+- `salesOrderNumber`: the sales order number as known in the supplier's ERP
+  system
+- `salesOrderPosition`: the position within the supplier's sales order
+- `description`: a free format additional description of this line by the
+  supplier
+- `requests`: the supplier can request different delivery schedule and prices,
+  see below
+- `properties`: are key-value based custom fields, added by the supplier
+- `notes`: are simple custom fields, added by the supplier
+- `documents`: contain meta data, objectId or url, of attached documents by the
+  supplier.
 
 {% page-ref page="download-document.md" %}
 
 #### Supplier requests
 
-`lines.supplierLine.requests.proposal`: the supplier has proposed a different delivery schedule, prices and/or charge lines compared to the issued order line.
-`lines.supplierLine.requests.reopenRequest`: the supplier requests to reopen the confirmed order line. The supplier has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
+`lines.supplierLine.requests.proposal`: the supplier has proposed a different
+delivery schedule and prices compared to the issued order line.
+`lines.supplierLine.requests.reopenRequest`: the supplier requests to reopen the
+confirmed order line. The supplier has requested a different delivery schedule
+and prices compared to the confirmed order line.
 
-* `deliverySchedule`: the requested alternative delivery schedule
-* `prices`: the requested alternative prices
-* `chargeLines`: the requested alternative charge lines, see [Charge lines](#charge-lines)
-* `reason`: the reason of this request given by the supplier
-* `status`: the [Request status](../../status.md#request-status).
+- `deliverySchedule`: the requested alternative delivery schedule
+- `prices`: the requested alternative prices
+- `chargeLines` **(deprecated)**: the requested alternative charge lines, see
+  [Charge lines](#charge-lines)
+- `reason`: the reason of this request given by the supplier
+- `status`: the [Request status](../../status.md#request-status).
 
 ### Confirmed line
 
 `lines.confirmedLine`: the agreed order line between buyer and supplier.
 
 {% hint style="warning" %}
-Only if the process status is `Confirmed` the line is agreed between buyer and supplier
+Only if the process status is `Confirmed` the line is agreed between buyer and
+supplier
 {% endhint %}
 
-* `lines.confirmedLine.deliverySchedule`: the agreed delivery schedule
-* `lines.confirmedLine.prices`: the agreed prices
-* `lines.confirmedLine.chargeLines`: the agreed charge lines, see [Charge lines](#charge-lines)
+- `lines.confirmedLine.deliverySchedule`: the agreed delivery schedule
+- `lines.confirmedLine.prices`: the agreed prices
+- `lines.confirmedLine.chargeLines` **(deprecated)**: the agreed charge lines,
+  see [Charge lines](#charge-lines)
 
 ### Delivery schedule
 
 When using `order` or `orderEvent` the delivery schedule is used.
 
 {% hint style="info" %}
-The `lines.deliverySchedule` together with the `lines.prices` fields give a simpler alternative for the `deliverySchedule` and `prices` fields in different places like `buyerLine`, `buyerLine.requests`, `supplierLine.requests` and `confirmedLine`.
+The `lines.deliverySchedule` together with the `lines.prices` fields give a
+simpler alternative for the `deliverySchedule` and `prices` fields in different
+places like `buyerLine`, `buyerLine.requests`, `supplierLine.requests` and
+`confirmedLine`.
 {% endhint %}
 
-* `lines.deliverySchedule`: the current delivery schedule, either having `Issued` or `Confirmed` values.
+- `lines.deliverySchedule`: the current delivery schedule, either having
+  `Issued` or `Confirmed` values.
 
 {% hint style="warning" %}
-The `lines.deliverySchedule` field does **NOT include any open supplier or buyer request**. Be aware that either the `Issued` or `Confirmed` values are returned, dependent on the line status.
+The `lines.deliverySchedule` field does **NOT include any open supplier or buyer
+request**. Be aware that either the `Issued` or `Confirmed` values are returned,
+dependent on the line status.
 {% endhint %}
 
-* `lines.deliveryScheduleIncludingRequests`: the current delivery schedule, either having `Issued`, `In Progress` or `Confirmed` values.
+- `lines.deliveryScheduleIncludingRequests`: the current delivery schedule,
+  either having `Issued`, `In Progress` or `Confirmed` values.
 
 {% hint style="warning" %}
-The `lines.deliveryScheduleIncludingRequests` field **does include any open supplier or buyer request**. Be aware that the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
+The `lines.deliveryScheduleIncludingRequests` field **does include any open
+supplier or buyer request**. Be aware that the `Issued`, proposal or reopen
+request or `Confirmed` values are returned, dependent on the line and request
+status.
 {% endhint %}
 
 #### Delivery schedule fields
 
-* `lines.deliverySchedule[IncludingRequests].position`: the optional position in the delivery schedule. Not to be confused with the `line.position`
-* `lines.deliverySchedule[IncludingRequests].date`: the delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-* `lines.deliverySchedule[IncludingRequests].quantity`: the quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
+- `lines.deliverySchedule[IncludingRequests].position`: the optional position in
+  the delivery schedule. Not to be confused with the `line.position`
+- `lines.deliverySchedule[IncludingRequests].date`: the delivery date of this
+  delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See
+  also [Standards](../../api/standards.md).
+- `lines.deliverySchedule[IncludingRequests].quantity`: the quantity of this
+  delivery schedule position. Quantity has a decimal `1234.56` format with any
+  number of digits.
 
 ##### Logistics fields
 
-These additional logistics fields are only available in the order line level delivery schedule:
+These additional logistics fields are only available in the order line level
+delivery schedule:
 
-* `lines.deliverySchedule[IncludingRequests].status`: the optional delivery line's [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status).
-* `lines.deliverySchedule[IncludingRequests].etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-* `lines.deliverySchedule[IncludingRequests].eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+- `lines.deliverySchedule[IncludingRequests].status`: the optional delivery
+  line's [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status).
+- `lines.deliverySchedule[IncludingRequests].etd`: The optional logistics
+  Estimated Time of Departure \(local date without time zone\). Date has ISO
+  8601 date `yyyy-MM-dd` format.
+- `lines.deliverySchedule[IncludingRequests].eta`: The optional logistics
+  Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601
+  date `yyyy-MM-dd` format.
 
-See [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status) for the complete list of values.
+See [Scheduled delivery logistics
+status](../../status.md#scheduled-delivery-logistics-status) for the complete
+list of values.
 
 ### Prices
 
-* `lines.prices`: the current prices, either having `Issued` or `Confirmed` values.
+- `lines.prices`: the current prices, either having `Issued` or `Confirmed`
+  values.
 
 {% hint style="warning" %}
-The `lines.prices` field does **NOT include any open supplier or buyer request**. Be aware that either the `Issued` or `Confirmed` values are returned, dependent on the line status.
+The `lines.prices` field does **NOT include any open supplier or buyer
+request**. Be aware that either the `Issued` or `Confirmed` values are returned,
+dependent on the line status.
 {% endhint %}
 
-* `lines.pricesIncludingRequests`: the current prices, either having `Issued`, `In Progress` or `Confirmed` values.
+- `lines.pricesIncludingRequests`: the current prices, either having `Issued`,
+  `In Progress` or `Confirmed` values.
 
 {% hint style="warning" %}
-The `lines.pricesIncludingRequests` field **includes any open supplier or buyer request**. Be aware that the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
+The `lines.pricesIncludingRequests` field **includes any open supplier or buyer
+request**. Be aware that the `Issued`, proposal or reopen request or `Confirmed`
+values are returned, dependent on the line and request status.
 {% endhint %}
 
 #### Prices fields
 
-* `lines.prices[IncludingRequests].grossPrice`: the gross price. Used together with `discountPercentage`.
-* `lines.prices[IncludingRequests].discountPercentage`: the discount percentage. Used together with `grossPrice`.
-* `lines.prices[IncludingRequests].netPrice`: the net price.
-  * `priceInTransactionCurrency`: the price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
-  * `priceInBaseCurrency`: the price in your base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-* `lines.prices[IncludingRequests].priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
+- `lines.prices[IncludingRequests].grossPrice`: the gross price. Used together
+  with `discountPercentage`.
+- `lines.prices[IncludingRequests].discountPercentage`: the discount percentage.
+  Used together with `grossPrice`.
+- `lines.prices[IncludingRequests].netPrice`: the net price.
+  - `priceInTransactionCurrency`: the price in the transaction currency of the
+    supplier, like `CNY` in China.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`, `USD` and `CNY`
+  - `priceInBaseCurrency`: the price in your base currency, like `EUR` in the
+    EU.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`.
+- `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the 3-letter price
+  unit according to ISO 80000-1. The purchase unit and price unit may be
+  different.
+- `lines.prices[IncludingRequests].priceUnitQuantity`: the item quantity at
+  which the price applies. Typically this is 1 \(unit price\) or 100 \(the price
+  applies to 100 items\)
 
 {% hint style="info" %}
-It is advised to only use `netPrice` for its simplicity, or alternatively use `grossPrice` together with `discountPercentage`.
+It is advised to only use `netPrice` for its simplicity, or alternatively use
+`grossPrice` together with `discountPercentage`.
 {% endhint %}
 
 ### Line status
 
-See [Line status](../../status.md#line-status) for the complete list of line process, in progress and logistics status values.
+See [Line status](../../status.md#line-status) for the complete list of line
+process, in progress and logistics status values.
 
 ### Charge lines
 
-`chargeLines`: the requested or confirmed additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
-
-* `position`: the position used to identify a charge line.
-* `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
-* `chargeDescription`: a mandatory free text description, like "Transport costs".
-* `quantity`: the mandatory quantity of this charge line.
-* `price`: the mandatory price of this charge line.
-  * `priceInTransactionCurrency`: the mandatory price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
-  * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1 which applies to the charge line price.
+{% hint style="warning" %}
+**Deprecated.** Charge lines (`chargeLines`) are deprecated. The following is
+retained for existing integrations only.
+{% endhint %}
 
 ### Item details
 
 {% hint style="info" %}
 The buyer may send item details to inform the supplier about part information.  
-The supplier may check, change and add item details if they are not correct or incomplete.  
-`lines.mergedItemDetails` will contain the original item details added by the buyer merged with the changed or added item details by the supplier.
+The supplier may check, change and add item details if they are not correct or
+incomplete.
+`lines.mergedItemDetails` will contain the original item details added by the
+buyer merged with the changed or added item details by the supplier.
 {% endhint %}
 
-* `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture, production, or growth where an article or product comes from.
-* `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the requirements both of the Common Customs Tariff and of the EU's external trade statistics.
-* `netWeight`: Net weight of one item.
-* `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
-* `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that identify dangerous goods, hazardous substances and articles in the framework of international transport.
-* `serialNumber`: is an unique identifier assigned incrementally or sequentially to an item, to uniquely identify it.
-* `batchNumber`: is an identification number assigned to a particular quantity or lot of material from a single manufacturer
+- `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture,
+  production, or growth where an article or product comes from.
+- `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the
+  requirements both of the Common Customs Tariff and of the EU's external trade
+  statistics.
+- `netWeight`: Net weight of one item.
+- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
+  identify dangerous goods, hazardous substances and articles in the framework
+  of international transport.
+- `serialNumber`: is an unique identifier assigned incrementally or sequentially
+  to an item, to uniquely identify it.
+- `batchNumber`: is an identification number assigned to a particular quantity
+  or lot of material from a single manufacturer
 
 ## Message meta information
 
 - `messageId`: The Tradecloud identifier of this message
 - `source`: Includes meta information about the source of this message:
 
-  - `traceId`: The Tradecloud trace identifier of this message. All related messages in a flow will have the same traceId
-  - `userId`: The Tradecloud user identifier which triggered the first message in a flow
-  - `companyId`: The Tradecloud company identifier which triggered the first message in a flow
+  - `traceId`: The Tradecloud trace identifier of this message. All related
+    messages in a flow will have the same traceId
+  - `userId`: The Tradecloud user identifier which triggered the first message
+    in a flow
+  - `companyId`: The Tradecloud company identifier which triggered the first
+    message in a flow
 
 - `createdDateTime`: Date and time with time zone when this message was created

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -50,7 +50,7 @@ The order header contains:
   logistics status](../../status.md#order-logistics-status).
 - `version`: the Tradecloud order version number
 - `eventDates`: some key order event date/times
-- `meta`: meta information, including source and trace info, about this messsage
+- `meta`: meta information, including source and trace info, about this message
 - `lastUpdatedAt`: is the latest date time the order has been changed.
 
 ### Buyer order
@@ -95,11 +95,11 @@ The order status is the aggregation of all the lines statuses. See
   line](#supplier-line).
 - `confirmedLine`: the order line as agreed between buyer and supplier.
 - `statusLine`: the order line values representing the current `Issued`,
-  `Confirmed` or `InProgess` status, see [Status line](#status-line).
+  `Confirmed` or `InProgress` status, see [Status line](#status-line).
 - `indicators.deliveryOverdue` is true when the order line is overdue.
 - `status.processStatus`: the order line's [Line process
   status](../../status.md#line-process-status).
-- `status.inProgressStatus` the order line's [Line in progress
+- `status.inProgressStatus`: the order line's [Line in progress
   status](../../status.md#line-in-progress-status).
 - `status.logisticsStatus`: the order line's [Line logistics
   status](../../status.md#line-logistics-status).

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -4,9 +4,12 @@ description: How to receive a single delivery order response sent by the supplie
 
 # Receive a single delivery order response
 
-Tradecloud sends purchase order responses to buyers when order events are triggered. This page covers receiving responses with a single scheduled delivery per order line.
+Tradecloud sends purchase order responses to buyers when order events are
+triggered. This page covers receiving responses with a single scheduled delivery
+per order line.
 
-If you prefer to work with delivery schedules (multiple deliveries per order line), please refer to:
+If you prefer to work with delivery schedules (multiple deliveries per order
+line), please refer to:
 
 {% page-ref page="README.md" %}
 
@@ -16,14 +19,16 @@ There are two methods to receive order responses with single deliveries:
 
 ### Method 1: Order webhook (Push)
 
-Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost)
+endpoint.
 
 - `eventName` contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events)
 - `singleDeliveryOrderEvent` contains the actual order event
 
 ### Method 2: Polling (Pull)
 
-Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) endpoint.
+Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute)
+endpoint.
 
 - `order` contains the actual order in its current state
 
@@ -33,142 +38,207 @@ Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url
 
 The order header contains:
 
-* `id` (in `order`) or `orderId` (in `singleDeliveryOrderEvent`): Tradecloud order identifier
-* `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order)
-* `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order)
-* `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines statuses, see [Order process status](../../status.md#order-process-status).
-* `status.logisticsStatus`: is the aggregate of all lines statuses, see [Order logistics status](../../status.md#order-logistics-status).
-* `version`: the Tradecloud order version number
-* `eventDates`: some key order event date/times
-* `meta`: meta information, including source and trace info, about this messsage
-* `lastUpdatedAt`: is the latest date time the order has been changed.
+- `id` (in `order`) or `orderId` (in `singleDeliveryOrderEvent`): Tradecloud
+  order identifier
+- `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order)
+- `supplierOrder`: the supplier part of the order, see
+  [Supplier order](#supplier-order)
+- `indicators.deliveryOverdue` is true when at least one order line is overdue.
+- `status.processStatus`: is the aggregate of all lines statuses, see
+  [Order process status](../../status.md#order-process-status).
+- `status.logisticsStatus`: is the aggregate of all lines statuses, see [Order
+  logistics status](../../status.md#order-logistics-status).
+- `version`: the Tradecloud order version number
+- `eventDates`: some key order event date/times
+- `meta`: meta information, including source and trace info, about this messsage
+- `lastUpdatedAt`: is the latest date time the order has been changed.
 
 ### Buyer order
 
-`buyerOrder` is mostly an echo of your order fields as explained in [Issue a new order](../issue/#order-body-json-objects)
+`buyerOrder` is mostly an echo of your order fields as explained in
+[Issue a new order](../issue/#order-body-json-objects)
 
-* `supplierAccountNumber`: the supplier account number as known in your ERP system
+- `supplierAccountNumber`: the supplier account number as known in your ERP
+  system
 
 ### Supplier order
 
 `supplierOrder` contains the supplier order fields:
 
-* `companyId`: the supplier's Tradecloud company identifier.
-* `buyerAccountNumber`: your account number as known in the supplier's ERP system.
-* `description`: a free format additional description of this order by the supplier.
-* `contact`: the supplier employee responsible for this order.
-* `properties`: are key-value based custom fields, added by the supplier.
-* `notes`: are simple custom fields, added by the supplier.
-* `documents`: contain meta data and link of attached documents by the supplier.
+- `companyId`: the supplier's Tradecloud company identifier.
+- `buyerAccountNumber`: your account number as known in the supplier's ERP
+  system.
+- `description`: a free format additional description of this order by the
+  supplier.
+- `contact`: the supplier employee responsible for this order.
+- `properties`: are key-value based custom fields, added by the supplier.
+- `notes`: are simple custom fields, added by the supplier.
+- `documents`: contain meta data and link of attached documents by the supplier.
 
 {% page-ref page="download-document.md" %}
 
 ### Order status
 
-The order status is the aggregation of all the lines statuses. See [Order status](../../status.md#order-status) for the complete list of values.
+The order status is the aggregation of all the lines statuses. See
+[Order status](../../status.md#order-status) for the complete list of values.
 
 ## `singleDeliveryOrderEvent` lines
 
 `lines` contains one or more order lines:
 
-* `id`: the Tradecloud line identifier
-* `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
-* `supplierLine`: the supplier part of the order line, see [Supplier line](#supplier-line).
-* `confirmedLine`: the order line as agreed between buyer and supplier.
-* `statusLine`: the order line values representing the current `Issued`, `Confirmed` or `InProgess` status, see [Status line](#status-line).
-* `indicators.deliveryOverdue` is true when the order line is overdue.
-* `status.processStatus`: the order line's [Line process status](../../status.md#line-process-status).
-* `status.inProgressStatus` the order line's [Line in progress status](../../status.md#line-in-progress-status).
-* `status.logisticsStatus`: the order line's [Line logistics status](../../status.md#line-logistics-status).
-* `eventDates`: some key line event date/times
-* `mergedItemDetails`: detailed part information provided by both buyer and supplier, see [Item details](#item-details).
-* `lastUpdatedAt`: is the latest date time the order line has been changed.
+- `id`: the Tradecloud line identifier
+- `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
+- `supplierLine`: the supplier part of the order line, see [Supplier
+  line](#supplier-line).
+- `confirmedLine`: the order line as agreed between buyer and supplier.
+- `statusLine`: the order line values representing the current `Issued`,
+  `Confirmed` or `InProgess` status, see [Status line](#status-line).
+- `indicators.deliveryOverdue` is true when the order line is overdue.
+- `status.processStatus`: the order line's [Line process
+  status](../../status.md#line-process-status).
+- `status.inProgressStatus` the order line's [Line in progress
+  status](../../status.md#line-in-progress-status).
+- `status.logisticsStatus`: the order line's [Line logistics
+  status](../../status.md#line-logistics-status).
+- `eventDates`: some key line event date/times
+- `mergedItemDetails`: detailed part information provided by both buyer and
+  supplier, see [Item details](#item-details).
+- `lastUpdatedAt`: is the latest date time the order line has been changed.
 
 ### Buyer line
 
-`lines.buyerLine` is an echo of your order line fields as explained in [Issue a new order](../issue/#lines)
+`lines.buyerLine` is an echo of your order line fields as explained in [Issue a
+new order](../issue/#lines)
 
-* `position`: the line position within the purchase order. The position is unique and immutable within the order. Position is empty in case of a newly split line.
-* `originalPosition`: The original position when `position` is empty in case of a split line.
+- `position`: the line position within the purchase order. The position is
+  unique and immutable within the order. Position is empty in case of a newly
+  split line.
+- `originalPosition`: The original position when `position` is empty in case of
+  a split line.
 
 ### Supplier line
 
 `lines.supplierLine` contains the supplier order line fields:
 
-* `salesOrderNumber`: the sales order number as known in the supplier's ERP system
-* `salesOrderPosition`: the position within the supplier's sales order
-* `description`: a free format additional description of this line by the supplier
-* `requests`: the supplier can request different delivery schedule, prices and charge lines. Advised is to use the `statusLine.deliveryScheduleInclRequests` and `statusLine.pricesInclRequests` fields instead.
-* `properties`: are key-value based custom fields, added by the supplier
-* `notes`: are simple custom fields, added by the supplier
-* `documents`: contain meta data, objectId or url, of attached documents by the supplier.
+- `salesOrderNumber`: the sales order number as known in the supplier's ERP
+  system
+- `salesOrderPosition`: the position within the supplier's sales order
+- `description`: a free format additional description of this line by the
+  supplier
+- `requests`: the supplier can request different delivery schedule and prices.
+  Advised is to use the `statusLine.deliveryScheduleInclRequests` and
+  `statusLine.pricesInclRequests` fields instead.
+- `properties`: are key-value based custom fields, added by the supplier
+- `notes`: are simple custom fields, added by the supplier
+- `documents`: contain meta data, objectId or url, of attached documents by the
+  supplier.
 
 {% page-ref page="download-document.md" %}
 
 ### Status line
 
-`lines.statusLine` represents the current order line values related to the current `Issued`, `Confirmed` or `InProgress` process status. The `InclRequests` fields also include the `InProgress` status and related open buyer or supplier request values.
+`lines.statusLine` represents the current order line values related to the
+current `Issued`, `Confirmed` or `InProgress` process status. The `InclRequests`
+fields also include the `InProgress` status and related open buyer or supplier
+request values.
 
 #### Single delivery per order line
 
-When using `singleDeliveryOrderEvent` only one single delivery per order line is used:
+When using `singleDeliveryOrderEvent` only one single delivery per order line is
+used:
 
-* `lines.statusLine.scheduledDelivery`: the current delivery line, either having `Issued` or `Confirmed` values.
-* `lines.statusLine.scheduledDeliveryInclRequests`: the current delivery line, either having `Issued`, `InProgress` requests or `Confirmed` values.
+- `lines.statusLine.scheduledDelivery`: the current delivery line, either having
+  `Issued` or `Confirmed` values.
+- `lines.statusLine.scheduledDeliveryInclRequests`: the current delivery line,
+  either having `Issued`, `InProgress` requests or `Confirmed` values.
 
 ##### Scheduled delivery fields
 
-* `lines.statusLine.scheduledDelivery[InclRequests].date`: the delivery date of this delivery line. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-* `lines.statusLine.scheduledDelivery[InclRequests].quantity`: the quantity of this delivery line. Quantity has a decimal `1234.56` format with any number of digits.
+- `lines.statusLine.scheduledDelivery[InclRequests].date`: the delivery date of
+  this delivery line. Date has ISO 8601 date `yyyy-MM-dd` format. See also
+  [Standards](../../api/standards.md).
+- `lines.statusLine.scheduledDelivery[InclRequests].quantity`: the quantity of
+  this delivery line. Quantity has a decimal `1234.56` format with any number of
+  digits.
 
 ##### Scheduled delivery logistics fields
 
-These additional logistics fields are only available in the status line scheduled delivery:
+These additional logistics fields are only available in the status line
+scheduled delivery:
 
-* `lines.statusLine.scheduledDelivery[InclRequests].status`: the optional delivery line's [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status).
-* `lines.statusLine.scheduledDelivery[InclRequests].etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-* `lines.statusLine.scheduledDelivery[InclRequests].eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+- `lines.statusLine.scheduledDelivery[InclRequests].status`: the optional
+  delivery line's [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status).
+- `lines.statusLine.scheduledDelivery[InclRequests].etd`: The optional logistics
+  Estimated Time of Departure \(local date without time zone\). Date has ISO
+  8601 date `yyyy-MM-dd` format.
+- `lines.statusLine.scheduledDelivery[InclRequests].eta`: The optional logistics
+  Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601
+  date `yyyy-MM-dd` format.
 
 #### Prices
 
-* `lines.statusLine.prices`: the current prices, either having `Issued` or `Confirmed` values.
-* `lines.statusLine.pricesInclRequests`: the current delivery line, either having `Issued`, `InProgress` requests or `Confirmed` values.
+- `lines.statusLine.prices`: the current prices, either having `Issued` or
+  `Confirmed` values.
+- `lines.statusLine.pricesInclRequests`: the current delivery line, either
+  having `Issued`, `InProgress` requests or `Confirmed` values.
 
 ##### Prices fields
 
-* `lines.statusLine.prices[InclRequests].grossPrice`: the gross price. Used together with `discountPercentage`.
-* `lines.statusLine.prices[InclRequests].discountPercentage`: the discount percentage. Used together with `grossPrice`.
-* `lines.statusLine.prices[InclRequests].netPrice`: the net price.
-  * `priceInTransactionCurrency`: the price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
-  * `priceInBaseCurrency`: the price in your base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `lines.statusLine.prices[InclRequests].priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-* `lines.statusLine.prices[InclRequests].priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
+- `lines.statusLine.prices[InclRequests].grossPrice`: the gross price. Used
+  together with `discountPercentage`.
+- `lines.statusLine.prices[InclRequests].discountPercentage`: the discount
+  percentage. Used together with `grossPrice`.
+- `lines.statusLine.prices[InclRequests].netPrice`: the net price.
+  - `priceInTransactionCurrency`: the price in the transaction currency of the
+    supplier, like `CNY` in China.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`, `USD` and `CNY`
+  - `priceInBaseCurrency`: the price in your base currency, like `EUR` in the
+    EU.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`.
+- `lines.statusLine.prices[InclRequests].priceUnitOfMeasureIso`: the 3-letter
+  price unit according to ISO 80000-1. The purchase unit and price unit may be
+  different.
+- `lines.statusLine.prices[InclRequests].priceUnitQuantity`: the item quantity
+  at which the price applies. Typically this is 1 \(unit price\) or 100 \(the
+  price applies to 100 items\)
 
 {% hint style="info" %}
-It is advised to only use `netPrice` for its simplicity, or alternatively use `grossPrice` together with `discountPercentage`.
+It is advised to only use `netPrice` for its simplicity, or alternatively use
+`grossPrice` together with `discountPercentage`.
 {% endhint %}
 
 ### Line status
 
-See [Line status](../../status.md#line-status) for the complete list of line process, in progress and logistics status values.
+See [Line status](../../status.md#line-status) for the complete list of line
+process, in progress and logistics status values.
 
 ### Item details
 
 {% hint style="info" %}
 The buyer may send item details to inform the supplier about part information.  
-The supplier may check, change and add item details if they are not correct or incomplete.  
-`lines.mergedItemDetails` will contain the original item details added by the buyer merged with the changed or added item details by the supplier.
+The supplier may check, change and add item details if they are not correct or
+incomplete.
+`lines.mergedItemDetails` will contain the original item details added by the
+buyer merged with the changed or added item details by the supplier.
 {% endhint %}
 
-* `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture, production, or growth where an article or product comes from.
-* `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the requirements both of the Common Customs Tariff and of the EU's external trade statistics.
-* `netWeight`: Net weight of one item.
-* `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
-* `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that identify dangerous goods, hazardous substances and articles in the framework of international transport.
-* `serialNumber`: is an unique identifier assigned incrementally or sequentially to an item, to uniquely identify it.
-* `batchNumber`: is an identification number assigned to a particular quantity or lot of material from a single manufacturer
+- `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture,
+  production, or growth where an article or product comes from.
+- `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the
+  requirements both of the Common Customs Tariff and of the EU's external trade
+  statistics.
+- `netWeight`: Net weight of one item.
+- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
+  identify dangerous goods, hazardous substances and articles in the framework
+  of international transport.
+- `serialNumber`: is an unique identifier assigned incrementally or sequentially
+  to an item, to uniquely identify it.
+- `batchNumber`: is an identification number assigned to a particular quantity
+  or lot of material from a single manufacturer

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -87,6 +87,9 @@ The order status is the aggregation of all the lines statuses. See
 `lines` contains one or more order lines:
 
 - `id`: the Tradecloud line identifier
+- `lineType`: one of `Item`, `Service`, or `Charge`. See [Order line type](../../line-type.md)
+- `chargeReasonCode`: optional UNCL7161 code when the buyer set a charge
+  reason on the line
 - `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
 - `supplierLine`: the supplier part of the order line, see [Supplier
   line](#supplier-line).

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -113,8 +113,8 @@ new order](../issue/#lines)
 - `position`: the line position within the purchase order. The position is
   unique and immutable within the order. Position is empty in case of a newly
   split line.
-- `originalPosition`: The original position when `position` is empty in case of
-  a split line.
+- `originalPosition`: optional position referencing the original order line when
+  the line has been split
 
 ### Supplier line
 

--- a/order/buyer/reopen.md
+++ b/order/buyer/reopen.md
@@ -4,36 +4,52 @@ description: How to request the supplier to reopen an order line
 
 # Reopen an order
 
-If an order line is **confirmed** (buyer and supplier agreed on delivery schedule, prices and related fields), the buyer can **reopen** it to propose different values. Tradecloud creates a line-level reopen workflow task that the supplier can **approve**, **reject** or **answer with a proposal**.
+If an order line is **confirmed** (buyer and supplier agreed on delivery
+schedule, prices and related fields), the buyer can **reopen** it to propose
+different values. Tradecloud creates a line-level reopen workflow task that the
+supplier can **approve**, **reject** or **answer with a proposal**.
 
 ## When a reopen request is created
 
-When you **reissue** an order line and the **requested** `delivery schedule`, `prices` and/or `charge lines` are **not equal** to the **confirmed** `delivery schedule`, `prices` and `charge lines`, Tradecloud automatically creates a reopen workflow task for the supplier.
+When you **reissue** an order line and the **requested** `delivery schedule` and
+`prices` are **not equal** to the **confirmed** `delivery schedule` and
+`prices`, Tradecloud automatically creates a reopen workflow task for the
+supplier.
 
 When possible, provide the buyer line `reason` field.
 
 ## Update a reopen request that is in progress
 
-You may **change an open reopen request** by updating the order line again (same as creating a reopen: new requested values that still differ from confirmed).
+You may **change an open reopen request** by updating the order line again (same
+as creating a reopen: new requested values that still differ from confirmed).
 
 {% page-ref page="update.md" %}
 
 ## Revert a reopen request
 
-You can **withdraw** an open reopen request **without** waiting for the supplier to approve or reject it.
+You can **withdraw** an open reopen request **without** waiting for the
+supplier to approve or reject it.
 
-Send an order update where the **requested** `delivery schedule`, `prices` and `charge lines` are **equal** to the **confirmed** `delivery schedule`, `prices` and `charge lines` — i.e. you align your request with what was already agreed before the reopen.
+Send an order update where the **requested** `delivery schedule` and `prices`
+are **equal** to the **confirmed** `delivery schedule` and `prices` — i.e. you
+align your request with what was already agreed before the reopen.
 
-In that case there is nothing left to negotiate: Tradecloud **reverts** the reopen workflow instead of keeping the line in negotiation. The line can return to process status `Confirmed` and the line-level [`inProgressStatus`](../status.md#line-in-progress-status) is cleared.
+In that case there is nothing left to negotiate: Tradecloud **reverts** the
+reopen workflow instead of keeping the line in negotiation. The line can return
+to process status `Confirmed` and the line-level
+[`inProgressStatus`](../status.md#line-in-progress-status) is cleared.
 
-This is **not** the same as the supplier rejecting the reopen; you are explicitly matching the last confirmed agreement.
+This is **not** the same as the supplier rejecting the reopen; you are
+explicitly matching the last confirmed agreement.
 
-Webhook subscribers receive [`OrderLinesReopenRequestRevertedByBuyer`](../../../connectors/webhooks/order-events.md#order-reopen-request-by-buyer).
+Webhook subscribers receive
+[`OrderLinesReopenRequestRevertedByBuyer`](../../../connectors/webhooks/order-events.md#order-reopen-request-by-buyer).
 
 {% hint style="warning" %}
 This is a **request** to the supplier to reopen an already confirmed order line.
 
-The supplier has to **approve** the reopen request before Tradecloud accepts a **change** that still differs from the confirmed values.
+The supplier has to **approve** the reopen request before Tradecloud accepts a
+**change** that still differs from the confirmed values.
 {% endhint %}
 
 {% hint style="warning" %}
@@ -41,5 +57,6 @@ You cannot reopen a `Completed` or `Cancelled` line.
 {% endhint %}
 
 {% hint style="info" %}
-An order line with process status `Confirmed` becomes `InProgress` when a reopen request is open. See [Line process status](../status.md#line-process-status).
+An order line with process status `Confirmed` becomes `InProgress` when a reopen
+request is open. See [Line process status](../status.md#line-process-status).
 {% endhint %}

--- a/order/buyer/update.md
+++ b/order/buyer/update.md
@@ -110,5 +110,5 @@ Additional indicators may be set in an order update:
 - `erpLastChangeDateTime`: Date and time the order was updated in your ERP
   system. `DateTime` has ISO 8601 local date/time format `yyyy-MM-ddThh:mm:ss`.
   See also [Standards](../api/standards.md).
-- `erpLastChangedBy`: he user email or user name as known in your ERP system who
+- `erpLastChangedBy`: the user email or user name as known in your ERP system who
   updated this order

--- a/order/buyer/update.md
+++ b/order/buyer/update.md
@@ -4,67 +4,98 @@ description: How to update an existing purchase order as a buyer
 
 # Update an existing order
 
-As buyer you can send either a [new](issue/) or updated purchase order to Tradecloud.
+As buyer you can send either a [new](issue/) or updated purchase order to
+Tradecloud.
 
 ## Order process
 
 {% hint style="danger" %}
-Most supplier ERP integrations do not have the capability to automatically process an updated order. It will be processed manually by the supplier and the order will have a longer human response time.
+Most supplier ERP integrations do not have the capability to automatically
+process an updated order. It will be processed manually by the supplier and the
+order will have a longer human response time.
 {% endhint %}
 
-* If an order line has order process status `Issued` or `In Progress` and it is updated, it will keep the same status.
-* If the line has status `Rejected` \(by supplier\) and it is reissued, it will become `In Progress`.
-* If the line has status `Confirmed` and it is reopened, it will become `In Progress`.
-* If the line is `In Progress` with an open buyer reopen request and your update makes the **requested** delivery schedule, prices and charge lines **equal** to the **confirmed** values again, Tradecloud **reverts** that reopen request — see [Revert a reopen request](reopen.md#revert-a-reopen-request).
-* In case of any other status like `Completed` or `Cancelled` the order update will be ignored.
+- If an order line has order process status `Issued` or `In Progress` and it is
+  updated, it will keep the same status.
+- If the line has status `Rejected` \(by supplier\) and it is reissued, it will
+  become `In Progress`.
+- If the line has status `Confirmed` and it is reopened, it will become `In
+  Progress`.
+- If the line is `In Progress` with an open buyer reopen request and your update
+  makes the **requested** delivery schedule and prices **equal** to the
+  **confirmed** values again, Tradecloud **reverts** that reopen request — see
+  [Revert a reopen request](reopen.md#revert-a-reopen-request).
+- In case of any other status like `Completed` or `Cancelled` the order update
+  will be ignored.
 
 ### Endpoints
 
-Use the [Send order](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderByBuyerRoute) endpoint when your ERP system supports a delivery schedule natively.
+Use the [Send order](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderByBuyerRoute)
+endpoint when your ERP system supports a delivery schedule natively.
 
-Or use the [Send single delivery order](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendSingleDeliveryOrderByBuyerRoute) endpoint for the single delivery per order line feature.
+Or use the [Send single delivery order](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendSingleDeliveryOrderByBuyerRoute)
+endpoint for the single delivery per order line feature.
 
-Please see this page to choose between the delivery schedule or single delivery per order line:
+Please see this page to choose between the delivery schedule or single delivery
+per order line:
 
 {% page-ref page="issue/delivery-schedule.md" %}
 
-Tradecloud will update the order based on the `purchaseOrderNumber` and will add or update lines, delivery schedules and delivery histories where needed.
+Tradecloud will update the order based on the `purchaseOrderNumber` and will add
+or update lines, delivery schedules and delivery histories where needed.
 
-Order lines will be matched based on `lines.position`, `deliverySchedule.position` and `deliveryHistory.position`.
+Order lines will be matched based on `lines.position`,
+`deliverySchedule.position` and `deliveryHistory.position`.
 
 {% hint style="info" %}
-The order update should preferable only contain **order lines** that are **new or changed**. But you can also send all lines anyway.
+The order update should preferable only contain **order lines** that are **new
+or changed**. But you can also send all lines anyway.
 {% endhint %}
 
 ## Additional fields
 
 ### Actual delivery history
 
-The actual delivery history may be added in an order update when your ERP system supports a delivery schedule natively. These will be used to calculate the line `Overdue` indicator.
+The actual delivery history may be added in an order update when your ERP system
+supports a delivery schedule natively. These will be used to calculate the line
+`Overdue` indicator.
 
-* `lines.deliveryHistory`: the historical actual delivery schedule. Provide zero, one or multiple delivery history lines. Provide all delivery history lines in an update. The total number of delivery history lines is limited to 100 lines per order line. 
-* `deliveryHistory.position`: the position in the delivery schedule. Not to be confused with the `line.position`. `deliverySchedule.position` versus `deliveryHistory.position` do not have to use the same values.
-* `deliveryHistory.date`: the actual delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../api/standards.md).
-* `deliveryHistory.quantity`: the actual delivered quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
+- `lines.deliveryHistory`: the historical actual delivery schedule. Provide
+  zero, one or multiple delivery history lines. Provide all delivery history
+  lines in an update. The total number of delivery history lines is limited to
+  100 lines per order line.
+- `deliveryHistory.position`: the position in the delivery schedule. Not to be
+  confused with the `line.position`. `deliverySchedule.position` versus
+  `deliveryHistory.position` do not have to use the same values.
+- `deliveryHistory.date`: the actual delivery date of this delivery schedule
+  position. Date has ISO 8601 date `yyyy-MM-dd` format. See also
+  [Standards](../api/standards.md).
+- `deliveryHistory.quantity`: the actual delivered quantity of this delivery
+  schedule position. Quantity has a decimal `1234.56` format with any number of
+  digits.
 
 ### Actual delivery
 
 Or use the actual delivery field when using the single delivery per order line:
 
-* `lines.actualDelivery`: the actual delivery at the buyer for this order line.
-* `actualDelivery.date`: the actual delivery date of this delivery. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../api/standards.md).
-* `actualDelivery.quantity`: the actual delivered quantity of this delivery. Quantity has a decimal `1234.56` format with any number of digits.
+- `lines.actualDelivery`: the actual delivery at the buyer for this order line.
+- `actualDelivery.date`: the actual delivery date of this delivery. Date has ISO
+  8601 date `yyyy-MM-dd` format. See also [Standards](../api/standards.md).
+- `actualDelivery.quantity`: the actual delivered quantity of this delivery.
+  Quantity has a decimal `1234.56` format with any number of digits.
 
 {% hint style="warning" %}
-The `deliveryHistory` (multiple actual deliveries) field is not supported when using the single delivery feature.
-Let [support](../support.md) know when you need `deliveryHistory` for single delivery.
+The `deliveryHistory` (multiple actual deliveries) field is not supported when
+using the single delivery feature.
+Let [support](../support.md) know when you need `deliveryHistory` for single
+delivery.
 {% endhint %}
 
 ### Additional order and line indicators
 
 Additional indicators may be set in an order update:
 
-* `indicators`:
+- `indicators`:
 
 {% page-ref page="receive-goods.md" %}
 
@@ -76,5 +107,8 @@ Additional indicators may be set in an order update:
 
 ## Updated order meta data
 
-* `erpLastChangeDateTime`: Date and time the order was updated in your ERP system. `DateTime` has ISO 8601 local date/time format `yyyy-MM-ddThh:mm:ss`. See also [Standards](../api/standards.md).
-* `erpLastChangedBy`: he user email or user name as known in your ERP system who updated this order
+- `erpLastChangeDateTime`: Date and time the order was updated in your ERP
+  system. `DateTime` has ISO 8601 local date/time format `yyyy-MM-ddThh:mm:ss`.
+  See also [Standards](../api/standards.md).
+- `erpLastChangedBy`: he user email or user name as known in your ERP system who
+  updated this order

--- a/order/line-type.md
+++ b/order/line-type.md
@@ -23,13 +23,6 @@ line), instead of treating everything implicitly as merchandise.
 Omitting `lineType` is **backward compatible** when **sending** an order: those
 lines behave like **`Item`**, so existing integrations need no change.
 
-## When suppliers receive an order
-
-On webhook and poll payloads, each **`buyerLine`** includes **`lineType`**:
-`Item`, `Service`, or `Charge`. If the buyer did not send `lineType` on issue,
-you still receive **`Item`**. **`chargeReasonCode`** is present when the buyer
-provided one.
-
 ## `chargeReasonCode` on the line
 
 For **`Charge`** lines you can send an optional **`chargeReasonCode`** on the
@@ -45,13 +38,12 @@ Tradecloud does not necessarily require `chargeReasonCode` whenever `lineType`
 is `Charge`; enforce any business rules in your own ERP if needed.
 {% endhint %}
 
-## Relation to nested `chargeLines`
+## Relation to deprecated `chargeLines`
 
 Older integrations could attach extra costs with a nested **`chargeLines`**
 array on a line. That model is **deprecated** for new work: model a separate
 order line with `lineType` **`Charge`**, line-level pricing, and optionally
-`chargeReasonCode`. Legacy documentation for `chargeLines` remains for those
-integrations.
+`chargeReasonCode`.
 
 ## Portal behaviour for charge lines
 

--- a/order/line-type.md
+++ b/order/line-type.md
@@ -1,0 +1,65 @@
+---
+description: >-
+  Order line classification: Item, Service, and Charge lines (lineType) and optional chargeReasonCode.
+---
+
+# Order line type
+
+Every purchase order line can be classified with an optional **`lineType`**.
+That tells Tradecloud and your supplier whether the line is a physical item, a
+service, or a standalone charge (for example freight or handling on its own
+line), instead of treating everything implicitly as merchandise.
+
+## Values of `lineType`
+
+- **`Item`** — The line represents goods or a physical article. This is the
+  **default** if you omit `lineType`.
+- **`Service`** — The line represents a service (labour, subscription,
+  fee-for-service, and similar) rather than a stock item.
+- **`Charge`** — The line is **only** an allowance or charge (freight,
+  packaging, administration, and similar) as its own order line, usually with a
+  price on that line.
+
+Omitting `lineType` is **backward compatible** when **sending** an order: those
+lines behave like **`Item`**, so existing integrations need no change.
+
+## When suppliers receive an order
+
+On webhook and poll payloads, each **`buyerLine`** includes **`lineType`**:
+`Item`, `Service`, or `Charge`. If the buyer did not send `lineType` on issue,
+you still receive **`Item`**. **`chargeReasonCode`** is present when the buyer
+provided one.
+
+## `chargeReasonCode` on the line
+
+For **`Charge`** lines you can send an optional **`chargeReasonCode`** on the
+same order line (not inside nested objects). Values follow
+[UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/) (UN/CEFACT
+charge and allowance reason codes). Example: `FC` (freight).
+
+You may also use `chargeReasonCode` in other combinations as your process
+requires; the OpenAPI spec describes allowed shapes.
+
+{% hint style="warning" %}
+Tradecloud does not necessarily require `chargeReasonCode` whenever `lineType`
+is `Charge`; enforce any business rules in your own ERP if needed.
+{% endhint %}
+
+## Relation to nested `chargeLines`
+
+Older integrations could attach extra costs with a nested **`chargeLines`**
+array on a line. That model is **deprecated** for new work: model a separate
+order line with `lineType` **`Charge`**, line-level pricing, and optionally
+`chargeReasonCode`. Legacy documentation for `chargeLines` remains for those
+integrations.
+
+## Portal behaviour for charge lines
+
+In the Tradecloud portal, **suppliers cannot split** a buyer line that is a
+charge line. Negotiation (accept, reject, propose) otherwise follows the same
+line-level flow as other lines.
+
+## Where this appears in the docs
+
+- **Buyer — send an order**: [Line type and charge reason code](buyer/issue/README.md#line-type-and-charge-reason-code)
+- **Supplier — inbound order payload**: buyer lines in [Receive an order](supplier/receive/README.md#buyer-line)

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -4,7 +4,8 @@ description: How to receive a purchase order sent by the buyer
 
 # Receive an order
 
-Tradecloud sends purchase orders (new or updated) to suppliers when order events are triggered.
+Tradecloud sends purchase orders (new or updated) to suppliers when order events
+are triggered.
 
 ## Receiving methods
 
@@ -38,257 +39,348 @@ If you're using single delivery format, please see:
 
 ### Using the webhook API
 
-See the [Webhook setup guide](../../../connectors/webhooks/webhook-setup.md) for instructions on how to configure the webhook API.
+See the [Webhook setup guide](../../../connectors/webhooks/webhook-setup.md) for
+instructions on how to configure the webhook API.
 
-Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost)
+endpoint.
 
 - `eventName`: Contains the [Order event name](../../../connectors/webhooks/order-events.md)
 - `orderEvent`: Contains the actual order event
 
 ### Using the polling API
 
-See the [Polling setup guide](../../../api/polling/README.md) for instructions on how to configure polling.
+See the [Polling setup guide](../../../api/polling/README.md) for instructions
+on how to configure polling.
 
-Use the [POST poll](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute) endpoint.
+Use the [POST poll](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersRoute)
+endpoint.
 
 - `order`: Contains the actual order in its current state
 
 ## Order structure
 
-This section assumes you're using either the `orderEvent` webhook API or the `order` polling API.
+This section assumes you're using either the `orderEvent` webhook API or the
+`order` polling API.
 
 ### Order header
 
 The order header contains:
 
-* `id` (in `order`) or `orderId` (in `orderEvent`): Tradecloud order identifier
-* `buyerOrder`: the buyer part of the order, see below.
-* `supplierOrder`: the supplier part of the order.
-* `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines [Order process status](../../status.md#order-process-status).
-* `status.logisticsStatus`: is the aggregate of all lines [Order logistics status](../../status.md#order-logistics-status).
-* `version`: the  Tradecloud order version number.
-* `eventDates`: some key order event date/times.
-* `meta`: meta information, including source and trace info, about this messsage.
-* `lastUpdatedAt`: is the latest date time the order has been changed, useful for polling orders.
+- `id` (in `order`) or `orderId` (in `orderEvent`): Tradecloud order identifier
+- `buyerOrder`: the buyer part of the order, see below.
+- `supplierOrder`: the supplier part of the order.
+- `indicators.deliveryOverdue` is true when at least one order line is overdue.
+- `status.processStatus`: is the aggregate of all lines [Order process status](../../status.md#order-process-status).
+- `status.logisticsStatus`: is the aggregate of all lines [Order logistics status](../../status.md#order-logistics-status).
+- `version`: the  Tradecloud order version number.
+- `eventDates`: some key order event date/times.
+- `meta`: meta information, including source and trace info, about this
+  messsage.
+- `lastUpdatedAt`: is the latest date time the order has been changed, useful
+  for polling orders.
 
 ### Buyer order
 
 `buyerOrder` contains the buyer order fields:
 
-* `companyId`: the buyer's Tradecloud company identifier.
-* `supplierAccountNumber`: your account number as known in the buyer's ERP system.
-* `description`: a free format additional description of this order added by the buyer.
-* `contact`: the buyer employee responsible for this order.
-* `properties`: are key-value based custom fields, added by the buyer.
-* `notes`: are simple custom fields, added by the buyer.
-* `labels`: value-added services labels on order level.
-* `documents`: contain meta data, objectId or url, of attached documents by the buyer. See:
+- `companyId`: the buyer's Tradecloud company identifier.
+- `supplierAccountNumber`: your account number as known in the buyer's ERP
+  system.
+- `description`: a free format additional description of this order added by the
+  buyer.
+- `contact`: the buyer employee responsible for this order.
+- `properties`: are key-value based custom fields, added by the buyer.
+- `notes`: are simple custom fields, added by the buyer.
+- `labels`: value-added services labels on order level.
+- `documents`: contain meta data, objectId or url, of attached documents by the
+  buyer. See:
 
 {% page-ref page="download-document.md" %}
 
-* `orderType`: the order type, one of `Purchase`, `Forecast` or `RFQ`. Default `Purchase`.
+- `orderType`: the order type, one of `Purchase`, `Forecast` or `RFQ`. Default
+  `Purchase`.
 
 ### Supplier order
 
-`supplierOrder` is mostly an echo of your order fields as explained in [Send order response](../send-order-response/)​.
+`supplierOrder` is mostly an echo of your order fields as explained in
+[Send order response](../send-order-response/)​.
 
-* `buyerAccountNumber`: the buyer account number as known in your ERP system.
+- `buyerAccountNumber`: the buyer account number as known in your ERP system.
 
 {% hint style="warning" %}
-The `buyerAccountNumber` should be set on forehand in the Tradecloud connection with your buyer. You can set the account code when inviting a new connection or in the connection overview in the portal.
+The `buyerAccountNumber` should be set on forehand in the Tradecloud connection
+with your buyer. You can set the account code when inviting a new connection or
+in the connection overview in the portal.
 {% endhint %}
 
 ### Order status
 
-The order status is the aggregation of all the lines statuses. See [Order status](../../status.md#order-status) for the complete list of values.
+The order status is the aggregation of all the lines statuses. See
+[Order status](../../status.md#order-status) for the complete list of values.
 
 ## `orderEvent` or `order` lines
 
 `lines` contains one or more order lines:
 
-* `id`: the Tradecloud line identifier.
-* `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line) below.
-* `supplierLine`: the supplier part of the order line, see [Supplier line](#supplier-line) below.
-* `confirmedLine`: the order line as agreed between buyer and supplier, see [Confirmed line](#confirmed-line) below.
-* `deliverySchedule`: the current aggregated delivery schedule, see [Delivery schedule](#delivery-schedule).
-* `deliveryScheduleIncludingRequests`: the current aggregated delivery schedule including requests, see [Delivery schedule](#delivery-schedule).
-* `prices`: the actual prices, see [Prices](#prices) below.
-* `pricesIncludingRequests`: the actual prices, including any open supplier or buyer requests, see [Prices](#prices).
-* `indicators.deliveryOverdue` is true when the order line is overdue.
-* `status.processStatus`: the order line's [Line process status](../../status.md#line-process-status).
-* `status.inProgressStatus` the order line's [Line in progress status](../../status.md#line-in-progress-status).
-* `status.logisticsStatus`: the order line's [Line logistics status](../../status.md#line-logistics-status).
-* `eventDates`: some key line event date/times.
-* `mergedItemDetails`: detailed part information provided by both buyer and supplier, see [Item details](#item-details).
-* `lastUpdatedAt`: is the latest date time the order line has been changed, useful for polling.
+- `id`: the Tradecloud line identifier.
+- `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line)
+  below.
+- `supplierLine`: the supplier part of the order line, see [Supplier
+  line](#supplier-line) below.
+- `confirmedLine`: the order line as agreed between buyer and supplier, see
+  [Confirmed line](#confirmed-line) below.
+- `deliverySchedule`: the current aggregated delivery schedule, see
+  [Delivery schedule](#delivery-schedule).
+- `deliveryScheduleIncludingRequests`: the current aggregated delivery schedule
+  including requests, see [Delivery schedule](#delivery-schedule).
+- `prices`: the actual prices, see [Prices](#prices) below.
+- `pricesIncludingRequests`: the actual prices, including any open supplier or
+  buyer requests, see [Prices](#prices).
+- `indicators.deliveryOverdue` is true when the order line is overdue.
+- `status.processStatus`: the order line's [Line process status](../../status.md#line-process-status).
+- `status.inProgressStatus` the order line's [Line in progress status](../../status.md#line-in-progress-status).
+- `status.logisticsStatus`: the order line's [Line logistics status](../../status.md#line-logistics-status).
+- `eventDates`: some key line event date/times.
+- `mergedItemDetails`: detailed part information provided by both buyer and
+  supplier, see [Item details](#item-details).
+- `lastUpdatedAt`: is the latest date time the order line has been changed,
+  useful for polling.
 
 ### Buyer line
 
 `buyerLine` contains the buyer order line fields:
 
-* `position`: the line position within the purchase order
-* `description`: a free format additional description of this line
-* `item`: the item (or article, goods) to be delivered, see [Item](#item)
-* `requests`: the buyer can request different delivery schedule, prices and charge lines
-* `terms`: the line terms as agreed with your buyer
-  * `contractNumber`: the agreed framework contract number
-  * `contractPosition`: the related position within the framework contract
-* `projectNumber`: The buyer's project number reference
-* `productionNumber`:  The buyer's production number reference
-* `salesOrderNumber`:  The buyer's sales order number \(not be confused with your sales order number\)
-* `indicators.noDeliveryExpected`: No goods are expected to be delivered to the buyer, for example a service, fee or text line.
-* `indicators.delivered`: All goods are delivered at the buyer.
-* `properties`: are key-value based custom fields. `\n` may be used for a new line in the value.
-* `notes`: are simple custom fields. `\n` may be used for a new line.
-* `labels`: value-added services labels on line level.
-* `documents`: contain meta data and link of attached documents, see:
+- `position`: the line position within the purchase order
+- `lineType`: one of `Item`, `Service`, or `Charge`
+- `chargeReasonCode`: optional — UNCL7161 code when the buyer set a charge
+  reason on the line
+- `description`: a free format additional description of this line
+- `item`: the item (or article, goods) to be delivered, see [Item](#item)
+- `requests`: the buyer can request different delivery schedule and prices
+- `terms`: the line terms as agreed with your buyer
+  - `contractNumber`: the agreed framework contract number
+  - `contractPosition`: the related position within the framework contract
+- `projectNumber`: The buyer's project number reference
+- `productionNumber`:  The buyer's production number reference
+- `salesOrderNumber`: The buyer's sales order number \(not be confused with your
+  sales order number\)
+- `indicators.noDeliveryExpected`: No goods are expected to be delivered to the
+  buyer, for example a service, fee or text line.
+- `indicators.delivered`: All goods are delivered at the buyer.
+- `properties`: are key-value based custom fields. `\n` may be used for a new
+  line in the value.
+- `notes`: are simple custom fields. `\n` may be used for a new line.
+- `labels`: value-added services labels on line level.
+- `documents`: contain meta data and link of attached documents, see:
 
 {% page-ref page="download-document.md" %}
+
+### Line type and charge reason code
+
+- `lineType`: classifies the line as `Item`, `Service`, or `Charge`.
+- `chargeReasonCode`: optional — UNCL7161 charge or allowance reason code on the
+  line (for example `FC` for freight). Typically used together with `lineType`
+  `Charge`. See the [UNCL7161 code list](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/).
+
+{% hint style="info" %}
+See [Order line type](../../line-type.md) for a full overview (introduced with
+[TC-10879](https://tradecloud.atlassian.net/browse/TC-10879)).
+{% endhint %}
 
 #### Item
 
 `lines.buyerLine.item`: The item (or article, goods) to be delivered.
 
-* `number`: the item code or number as known in the buyer ERP system.
-* `revision`: the revision (or version) of this item number
-* `name`: the item short name
-* `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`
-* `supplierItemNumber`: the item code or number as known at the supplier.
+- `number`: the item code or number as known in the buyer ERP system.
+- `revision`: the revision (or version) of this item number
+- `name`: the item short name
+- `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a
+  typical example is `PCE`
+- `supplierItemNumber`: the item code or number as known at the supplier.
 
 {% hint style="warning" %}
-`item.number` and `supplierItemNumber` are optional and may be left empty by the buyer, for example in case of service or RFQ orders.
+`item.number` and `supplierItemNumber` are optional and may be left empty by the
+buyer, for example in case of service or RFQ orders.
 
-If the supplier cannot process the order line without `item.number` or `item.supplierItemNumber`, the supplier should reject the order line and provide a reason.
+If the supplier cannot process the order line without `item.number` or
+`item.supplierItemNumber`, the supplier should reject the order line and provide
+a reason.
 
-`item.number` should be unique within the buyer's company and should never change.
+`item.number` should be unique within the buyer's company and should never
+change.
 {% endhint %}
 
 #### Buyer requests
 
-`lines.buyerLine.requests.reopenRequest`: the buyer requests to reopen the confirmed order line. The buyer has requested a different delivery schedule, prices and/or charge lines compared to the confirmed order line.
+`lines.buyerLine.requests.reopenRequest`: the buyer requests to reopen the
+confirmed order line. The buyer has requested a different delivery schedule and
+prices compared to the confirmed order line.
 
-* `deliverySchedule`: the requested alternative delivery schedule
-* `prices`: the requested alternative prices
-* `chargeLines`: the requested alternative charge lines, see [Charge lines](#charge-lines)
-* `reason`: the reason of this request given by the supplier
-* `status`: the [Request status](../../status.md#request-status).
+- `deliverySchedule`: the requested alternative delivery schedule
+- `prices`: the requested alternative prices
+- `chargeLines` **(deprecated)**: the requested alternative charge lines, see
+  [Charge lines](#charge-lines)
+- `reason`: the reason of this request given by the supplier
+- `status`: the [Request status](../../status.md#request-status).
 
 ### Supplier line
 
-`supplierLine` is an echo of your order line fields as explained in [Send order response](../send-order-response/)​.
+`supplierLine` is an echo of your order line fields as explained in
+[Send order response](../send-order-response/)​.
 
 ### Confirmed line
 
 `lines.confirmedLine`: the agreed order line between buyer and supplier.
 
 {% hint style="warning" %}
-Only if the process status is `Confirmed` the line is agreed between buyer and supplier
+Only if the process status is `Confirmed` the line is agreed between buyer and
+supplier
 {% endhint %}
 
-* `lines.confirmedLine.deliverySchedule`: the agreed delivery schedule
-* `lines.confirmedLine.prices`: the agreed prices
-* `lines.confirmedLine.chargeLines`: the agreed charge lines, see [Charge lines](#charge-lines)
+- `lines.confirmedLine.deliverySchedule`: the agreed delivery schedule
+- `lines.confirmedLine.prices`: the agreed prices
+- `lines.confirmedLine.chargeLines` **(deprecated)**: the agreed charge lines,
+  see [Charge lines](#charge-lines)
 
 ### Delivery schedule
 
 When using `order` or `orderEvent` the delivery schedule is used.
 
 {% hint style="info" %}
-The `lines.deliverySchedule` together with the `lines.prices` fields give a simpler alternative for the `deliverySchedule` and `prices` fields in different places like `buyerLine`, `buyerLine.requests`, `supplierLine.requests` and `confirmedLine`.
+The `lines.deliverySchedule` together with the `lines.prices` fields give a
+simpler alternative for the `deliverySchedule` and `prices` fields in different
+places like `buyerLine`, `buyerLine.requests`, `supplierLine.requests` and
+`confirmedLine`.
 {% endhint %}
 
-* `lines.deliverySchedule`: the current delivery schedule, either having `Issued` or `Confirmed` values.
+- `lines.deliverySchedule`: the current delivery schedule, either having
+  `Issued` or `Confirmed` values.
 
 {% hint style="warning" %}
-The `lines.deliverySchedule` field does **NOT include any open supplier or buyer request**. Be aware that either the `Issued` or `Confirmed` values are returned, dependent on the line status.
+The `lines.deliverySchedule` field does **NOT include any open supplier or buyer
+request**. Be aware that either the `Issued` or `Confirmed` values are returned,
+dependent on the line status.
 {% endhint %}
 
-* `lines.deliveryScheduleIncludingRequests`: the current delivery schedule, either having `Issued`, `In Progress` or `Confirmed` values.
+- `lines.deliveryScheduleIncludingRequests`: the current delivery schedule,
+  either having `Issued`, `In Progress` or `Confirmed` values.
 
 {% hint style="warning" %}
-The `lines.deliveryScheduleIncludingRequests` field **does include any open supplier or buyer request**. Be aware that the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
+The `lines.deliveryScheduleIncludingRequests` field **does include any open
+supplier or buyer request**. Be aware that the `Issued`, proposal or reopen
+request or `Confirmed` values are returned, dependent on the line and request
+status.
 {% endhint %}
 
 #### Delivery schedule fields
 
-* `lines.deliverySchedule[IncludingRequests].position`: the optional position in the delivery schedule. Not to be confused with the `line.position`
-* `lines.deliverySchedule[IncludingRequests].date`: the delivery date of this delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-* `lines.deliverySchedule[IncludingRequests].quantity`: the quantity of this delivery schedule position. Quantity has a decimal `1234.56` format with any number of digits.
+- `lines.deliverySchedule[IncludingRequests].position`: the optional position in
+  the delivery schedule. Not to be confused with the `line.position`
+- `lines.deliverySchedule[IncludingRequests].date`: the delivery date of this
+  delivery schedule position. Date has ISO 8601 date `yyyy-MM-dd` format. See
+  also [Standards](../../api/standards.md).
+- `lines.deliverySchedule[IncludingRequests].quantity`: the quantity of this
+  delivery schedule position. Quantity has a decimal `1234.56` format with any
+  number of digits.
 
 ##### Logistics fields
 
-These additional logistics fields are only available in the order line level delivery schedule:
+These additional logistics fields are only available in the order line level
+delivery schedule:
 
-* `lines.deliverySchedule[IncludingRequests].status`: the optional delivery line's [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status).
-* `lines.deliverySchedule[IncludingRequests].etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-* `lines.deliverySchedule[IncludingRequests].eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+- `lines.deliverySchedule[IncludingRequests].status`: the optional delivery
+  line's [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status).
+- `lines.deliverySchedule[IncludingRequests].etd`: The optional logistics
+  Estimated Time of Departure \(local date without time zone\). Date has ISO
+  8601 date `yyyy-MM-dd` format.
+- `lines.deliverySchedule[IncludingRequests].eta`: The optional logistics
+  Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601
+  date `yyyy-MM-dd` format.
 
 ### Prices
 
-* `lines.prices`: the current prices, either having `Issued` or `Confirmed` values.
+- `lines.prices`: the current prices, either having `Issued` or `Confirmed`
+  values.
 
 {% hint style="warning" %}
-The `lines.prices` field does **NOT include any open supplier or buyer request**. Be aware that either the `Issued` or `Confirmed` values are returned, dependent on the line status.
+The `lines.prices` field does **NOT include any open supplier or buyer
+request**. Be aware that either the `Issued` or `Confirmed` values are returned,
+dependent on the line status.
 {% endhint %}
 
-* `lines.pricesIncludingRequests`: the current prices, either having `Issued`, `In Progress` or `Confirmed` values.
+- `lines.pricesIncludingRequests`: the current prices, either having `Issued`,
+  `In Progress` or `Confirmed` values.
 
 {% hint style="warning" %}
-The `lines.pricesIncludingRequests` field **includes any open supplier or buyer request**. Be aware that the `Issued`, proposal or reopen request or `Confirmed` values are returned, dependent on the line and request status.
+The `lines.pricesIncludingRequests` field **includes any open supplier or buyer
+request**. Be aware that the `Issued`, proposal or reopen request or `Confirmed`
+values are returned, dependent on the line and request status.
 {% endhint %}
 
 #### Prices fields
 
-* `lines.prices[IncludingRequests].grossPrice`: the gross price. Used together with `discountPercentage`.
-* `lines.prices[IncludingRequests].discountPercentage`: the discount percentage. Used together with `grossPrice`.
-* `lines.prices[IncludingRequests].netPrice`: the net price.
-  * `priceInTransactionCurrency`: the price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
-  * `priceInBaseCurrency`: the price in your base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-* `lines.prices[IncludingRequests].priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
+- `lines.prices[IncludingRequests].grossPrice`: the gross price. Used together
+  with `discountPercentage`.
+- `lines.prices[IncludingRequests].discountPercentage`: the discount percentage.
+  Used together with `grossPrice`.
+- `lines.prices[IncludingRequests].netPrice`: the net price.
+  - `priceInTransactionCurrency`: the price in the transaction currency of the
+    supplier, like `CNY` in China.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`, `USD` and `CNY`
+  - `priceInBaseCurrency`: the price in your base currency, like `EUR` in the
+    EU.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`.
+- `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the 3-letter price
+  unit according to ISO 80000-1. The purchase unit and price unit may be
+  different.
+- `lines.prices[IncludingRequests].priceUnitQuantity`: the item quantity at
+  which the price applies. Typically this is 1 \(unit price\) or 100 \(the price
+  applies to 100 items\)
 
 {% hint style="info" %}
-It is advised to only use `netPrice` for its simplicity, or alternatively use `grossPrice` together with `discountPercentage`.
+It is advised to only use `netPrice` for its simplicity, or alternatively use
+`grossPrice` together with `discountPercentage`.
 {% endhint %}
 
 ### Line status
 
-See [Line status](../../status.md#line-status) for the complete list of line process, in progress and logistics status values.
+See [Line status](../../status.md#line-status) for the complete list of line
+process, in progress and logistics status values.
 
 ### Charge lines
 
-`chargeLines`: the requested or confirmed additional cost lines of an order line, independent of the order line prices, like transport, packing, administration, inspection and certification costs.
-
-* `position`: the position used to identify a charge line.
-* `chargeTypeCode`: the mandatory charge reason code according to [UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/)
-* `chargeDescription`: a mandatory free text description, like "Transport costs".
-* `quantity`: the mandatory quantity of this charge line.
-* `price`: the mandatory price of this charge line.
-  * `priceInTransactionCurrency`: the mandatory price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`.
-  * `priceInBaseCurrency`: the optional price in your base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1 which applies to the charge line price.
+{% hint style="warning" %}
+**Deprecated.** Charge lines (`chargeLines`) are deprecated.
+{% endhint %}
 
 ### Item details
 
 {% hint style="info" %}
 The buyer may send item details to inform the supplier about part information.  
-The supplier may check, change and add item details if they are not correct or incomplete.  
-`lines.mergedItemDetails` will contain the original item details added by the buyer merged with the changed or added item details by the supplier.
+The supplier may check, change and add item details if they are not correct or
+incomplete.
+`lines.mergedItemDetails` will contain the original item details added by the
+buyer merged with the changed or added item details by the supplier.
 {% endhint %}
 
-* `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture, production, or growth where an article or product comes from.
-* `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the requirements both of the Common Customs Tariff and of the EU's external trade statistics.
-* `netWeight`: Net weight of one item.
-* `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
-* `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that identify dangerous goods, hazardous substances and articles in the framework of international transport.
-* `serialNumber`: is an unique identifier assigned incrementally or sequentially to an item, to uniquely identify it.
-* `batchNumber`: is an identification number assigned to a particular quantity or lot of material from a single manufacturer
+- `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture,
+  production, or growth where an article or product comes from.
+- `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the
+  requirements both of the Common Customs Tariff and of the EU's external trade
+  statistics.
+- `netWeight`: Net weight of one item.
+- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
+  identify dangerous goods, hazardous substances and articles in the framework
+  of international transport.
+- `serialNumber`: is an unique identifier assigned incrementally or sequentially
+  to an item, to uniquely identify it.
+- `batchNumber`: is an identification number assigned to a particular quantity
+  or lot of material from a single manufacturer

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -124,6 +124,9 @@ The order status is the aggregation of all the lines statuses. See
 `lines` contains one or more order lines:
 
 - `id`: the Tradecloud line identifier.
+- `lineType`: one of `Item`, `Service`, or `Charge`. See [Order line type](../../line-type.md)
+- `chargeReasonCode`: optional UNCL7161 code when the buyer set a charge
+  reason on the line
 - `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line)
   below.
 - `supplierLine`: the supplier part of the order line, see [Supplier
@@ -152,9 +155,6 @@ The order status is the aggregation of all the lines statuses. See
 `buyerLine` contains the buyer order line fields:
 
 - `position`: the line position within the purchase order
-- `lineType`: one of `Item`, `Service`, or `Charge`
-- `chargeReasonCode`: optional — UNCL7161 code when the buyer set a charge
-  reason on the line
 - `description`: a free format additional description of this line
 - `item`: the item (or article, goods) to be delivered, see [Item](#item)
 - `requests`: the buyer can request different delivery schedule and prices
@@ -175,17 +175,6 @@ The order status is the aggregation of all the lines statuses. See
 - `documents`: contain meta data and link of attached documents, see:
 
 {% page-ref page="download-document.md" %}
-
-### Line type and charge reason code
-
-- `lineType`: classifies the line as `Item`, `Service`, or `Charge`.
-- `chargeReasonCode`: optional — UNCL7161 charge or allowance reason code on the
-  line (for example `FC` for freight). Typically used together with `lineType`
-  `Charge`. See the [UNCL7161 code list](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/).
-
-{% hint style="info" %}
-See [Order line type](../../line-type.md) for a full overview.
-{% endhint %}
 
 #### Item
 

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -184,8 +184,7 @@ The order status is the aggregation of all the lines statuses. See
   `Charge`. See the [UNCL7161 code list](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/).
 
 {% hint style="info" %}
-See [Order line type](../../line-type.md) for a full overview (introduced with
-[TC-10879](https://tradecloud.atlassian.net/browse/TC-10879)).
+See [Order line type](../../line-type.md) for a full overview.
 {% endhint %}
 
 #### Item
@@ -357,7 +356,8 @@ process, in progress and logistics status values.
 ### Charge lines
 
 {% hint style="warning" %}
-**Deprecated.** Charge lines (`chargeLines`) are deprecated.
+**Deprecated.** Charge lines (`chargeLines`) are deprecated. Superseded by `lineType`
+`Charge` and line-level pricing, see [Order line type](../../line-type.md).
 {% endhint %}
 
 ### Item details

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -73,7 +73,7 @@ The order header contains:
 - `indicators.deliveryOverdue` is true when at least one order line is overdue.
 - `status.processStatus`: is the aggregate of all lines [Order process status](../../status.md#order-process-status).
 - `status.logisticsStatus`: is the aggregate of all lines [Order logistics status](../../status.md#order-logistics-status).
-- `version`: the  Tradecloud order version number.
+- `version`: the Tradecloud order version number.
 - `eventDates`: some key order event date/times.
 - `meta`: meta information, including source and trace info, about this
   message.
@@ -209,7 +209,7 @@ prices compared to the confirmed order line.
 - `prices`: the requested alternative prices
 - `chargeLines` **(deprecated)**: the requested alternative charge lines, see
   [Charge lines](#charge-lines)
-- `reason`: the reason of this request given by the supplier
+- `reason`: the reason of this request given by the buyer
 - `status`: the [Request status](../../status.md#request-status).
 
 ### Supplier line
@@ -345,8 +345,9 @@ process, in progress and logistics status values.
 ### Charge lines
 
 {% hint style="warning" %}
-**Deprecated.** Charge lines (`chargeLines`) are deprecated. Superseded by `lineType`
-`Charge` and line-level pricing, see [Order line type](../../line-type.md).
+**Deprecated.** Charge lines (`chargeLines`) are deprecated. Superseded by
+`lineType = Charge` and line-level pricing, see
+[Order line type](../../line-type.md).
 {% endhint %}
 
 ### Item details
@@ -369,7 +370,7 @@ buyer merged with the changed or added item details by the supplier.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.
-- `serialNumber`: is an unique identifier assigned incrementally or sequentially
+- `serialNumber`: is a unique identifier assigned incrementally or sequentially
   to an item, to uniquely identify it.
 - `batchNumber`: is an identification number assigned to a particular quantity
   or lot of material from a single manufacturer

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -76,7 +76,7 @@ The order header contains:
 - `version`: the  Tradecloud order version number.
 - `eventDates`: some key order event date/times.
 - `meta`: meta information, including source and trace info, about this
-  messsage.
+  message.
 - `lastUpdatedAt`: is the latest date time the order has been changed, useful
   for polling orders.
 
@@ -87,10 +87,10 @@ The order header contains:
 - `companyId`: the buyer's Tradecloud company identifier.
 - `supplierAccountNumber`: your account number as known in the buyer's ERP
   system.
-- `description`: a free format additional description of this order added by the
+- `description`: a free-format additional description of this order added by the
   buyer.
 - `contact`: the buyer employee responsible for this order.
-- `properties`: are key-value based custom fields, added by the buyer.
+- `properties`: are key-value-based custom fields, added by the buyer.
 - `notes`: are simple custom fields, added by the buyer.
 - `labels`: value-added services labels on order level.
 - `documents`: contain meta data, objectId or url, of attached documents by the
@@ -142,7 +142,7 @@ The order status is the aggregation of all the lines statuses. See
   buyer requests, see [Prices](#prices).
 - `indicators.deliveryOverdue` is true when the order line is overdue.
 - `status.processStatus`: the order line's [Line process status](../../status.md#line-process-status).
-- `status.inProgressStatus` the order line's [Line in progress status](../../status.md#line-in-progress-status).
+- `status.inProgressStatus`: the order line's [Line in progress status](../../status.md#line-in-progress-status).
 - `status.logisticsStatus`: the order line's [Line logistics status](../../status.md#line-logistics-status).
 - `eventDates`: some key line event date/times.
 - `mergedItemDetails`: detailed part information provided by both buyer and
@@ -155,7 +155,7 @@ The order status is the aggregation of all the lines statuses. See
 `buyerLine` contains the buyer order line fields:
 
 - `position`: the line position within the purchase order
-- `description`: a free format additional description of this line
+- `description`: a free-format additional description of this line
 - `item`: the item (or article, goods) to be delivered, see [Item](#item)
 - `requests`: the buyer can request different delivery schedule and prices
 - `terms`: the line terms as agreed with your buyer
@@ -168,7 +168,7 @@ The order status is the aggregation of all the lines statuses. See
 - `indicators.noDeliveryExpected`: No goods are expected to be delivered to the
   buyer, for example a service, fee or text line.
 - `indicators.delivered`: All goods are delivered at the buyer.
-- `properties`: are key-value based custom fields. `\n` may be used for a new
+- `properties`: are key-value-based custom fields. `\n` may be used for a new
   line in the value.
 - `notes`: are simple custom fields. `\n` may be used for a new line.
 - `labels`: value-added services labels on line level.

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -96,6 +96,9 @@ The order status is the aggregation of all the lines statuses. See
 `lines` contains one or more order lines:
 
 - `id`: the Tradecloud line identifier
+- `lineType`: one of `Item`, `Service`, or `Charge`. See [Order line type](../../line-type.md)
+- `chargeReasonCode`: optional UNCL7161 code when the buyer set a charge
+  reason on the line
 - `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
 - `supplierLine`: the supplier part of the order line, see [Supplier
   line](#supplier-line).
@@ -121,11 +124,6 @@ The order status is the aggregation of all the lines statuses. See
 - `position`: the line position within the purchase order
 - `originalPosition`: optional position referencing the original order line when
   the line has been split
-- `lineType`: `Item`, `Service`, or `Charge` — **always present** when you
-  receive the order. If the buyer omitted `lineType` when issuing, the value is
-  **`Item`**.
-- `chargeReasonCode`: optional — UNCL7161 code when the buyer set a charge
-  reason on the line
 - `description`: a free format additional description of this line
 - `item`: the item (or article, goods) to be delivered, see [Item](#item)
 - `requests`: the buyer can request different delivery schedule and prices.
@@ -148,10 +146,6 @@ The order status is the aggregation of all the lines statuses. See
 - `documents`: contain meta data and link of attached documents, see:
 
 {% page-ref page="download-document.md" %}
-
-{% hint style="info" %}
-See [Order line type](../../line-type.md).
-{% endhint %}
 
 #### Item
 

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -119,6 +119,8 @@ The order status is the aggregation of all the lines statuses. See
 `buyerLine` contains the buyer order line fields:
 
 - `position`: the line position within the purchase order
+- `originalPosition`: optional position referencing the original order line when
+  the line has been split
 - `lineType`: `Item`, `Service`, or `Charge` — **always present** when you
   receive the order. If the buyer omitted `lineType` when issuing, the value is
   **`Item`**.

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -49,7 +49,7 @@ The order header contains:
 - `version`: the Tradecloud order version number.
 - `eventDates`: some key order event date/times.
 - `meta`: meta information, including source and trace info, about this
-  messsage.
+  message.
 - `lastUpdatedAt`: is the latest date time the order has been changed.
 
 ### Buyer order
@@ -104,11 +104,11 @@ The order status is the aggregation of all the lines statuses. See
   line](#supplier-line).
 - `confirmedLine`: the order line as agreed between buyer and supplier.
 - `statusLine`: the order line values representing the current `Issued`,
-  `Confirmed` or `InProgess` status, see [Status line](#status-line).
+  `Confirmed` or `InProgress` status, see [Status line](#status-line).
 - `indicators.deliveryOverdue` is true when the order line is overdue.
 - `status.processStatus`: the order line's [Line process
   status](../../status.md#line-process-status).
-- `status.inProgressStatus` the order line's [Line in progress
+- `status.inProgressStatus`: the order line's [Line in progress
   status](../../status.md#line-in-progress-status).
 - `status.logisticsStatus`: the order line's [Line logistics
   status](../../status.md#line-logistics-status).

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -4,9 +4,12 @@ description: How to receive a single delivery order sent by the buyer
 
 # Receive a single delivery order
 
-Tradecloud sends purchase orders (new or updated) to suppliers when order events are triggered. This page covers receiving orders with a single delivery per order line.
+Tradecloud sends purchase orders (new or updated) to suppliers when order events
+are triggered. This page covers receiving orders with a single delivery per
+order line.
 
-If you prefer to work with delivery schedules (multiple deliveries per order line), please refer to:
+If you prefer to work with delivery schedules (multiple deliveries per order
+line), please refer to:
 
 {% page-ref page="README.md" %}
 
@@ -14,14 +17,16 @@ If you prefer to work with delivery schedules (multiple deliveries per order lin
 
 ### Using the webhook API
 
-Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost) endpoint.
+Use the [POST order webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-webhook-connector/specs.yaml#/order-webhook%20endpoints/webhookPost)
+endpoint.
 
 - `eventName`: Contains the [order event name](https://docs.tradecloud1.com/connectors/webhook-connector/order-events)
 - `singleDeliveryOrderEvent`: Contains the actual order event
 
 ### Using the polling API
 
-Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute) endpoint.
+Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/order-search/specs.yaml#/order-search/pollOrdersSingleDeliveryRoute)
+endpoint.
 
 - `order`: Contains the actual order in its current state
 
@@ -31,165 +36,241 @@ Use the [POST poll/single-delivery](https://swagger-ui.accp.tradecloud1.com/?url
 
 The order header contains:
 
-* `id` (in `order`) or `orderId` (in `singleDeliveryOrderEvent`): Tradecloud order identifier
-* `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order).
-* `supplierOrder`: the supplier part of the order, see [Supplier order](#supplier-order).
-* `indicators.deliveryOverdue` is true when at least one order line is overdue.
-* `status.processStatus`: is the aggregate of all lines statuses, see [Order process status](../../status.md#order-process-status).
-* `status.logisticsStatus`: is the aggregate of all lines statuses, see [Order logistics status](../../status.md#order-logistics-status).
-* `version`: the Tradecloud order version number.
-* `eventDates`: some key order event date/times.
-* `meta`: meta information, including source and trace info, about this messsage.
-* `lastUpdatedAt`: is the latest date time the order has been changed.
+- `id` (in `order`) or `orderId` (in `singleDeliveryOrderEvent`): Tradecloud
+  order identifier
+- `buyerOrder`: the buyer part of the order, see [Buyer order](#buyer-order).
+- `supplierOrder`: the supplier part of the order, see
+  [Supplier order](#supplier-order).
+- `indicators.deliveryOverdue` is true when at least one order line is overdue.
+- `status.processStatus`: is the aggregate of all lines statuses, see
+  [Order process status](../../status.md#order-process-status).
+- `status.logisticsStatus`: is the aggregate of all lines statuses, see [Order
+  logistics status](../../status.md#order-logistics-status).
+- `version`: the Tradecloud order version number.
+- `eventDates`: some key order event date/times.
+- `meta`: meta information, including source and trace info, about this
+  messsage.
+- `lastUpdatedAt`: is the latest date time the order has been changed.
 
 ### Buyer order
 
 `buyerOrder` contains the buyer order fields:
 
-* `companyId`: the buyer's Tradecloud company identifier.
-* `supplierAccountNumber`: your account number as known in the buyer's ERP system.
-* `description`: a free format additional description of this order added by the buyer.
-* `contact`: the buyer employee responsible for this order.
-* `properties`: are key-value based custom fields, added by the buyer.
-* `notes`: are simple custom fields, added by the buyer.
-* `labels`: value-added services labels on order level.
-* `documents`: contain meta data, objectId or url, of attached documents by the buyer. See:
+- `companyId`: the buyer's Tradecloud company identifier.
+- `supplierAccountNumber`: your account number as known in the buyer's ERP
+  system.
+- `description`: a free format additional description of this order added by the
+  buyer.
+- `contact`: the buyer employee responsible for this order.
+- `properties`: are key-value based custom fields, added by the buyer.
+- `notes`: are simple custom fields, added by the buyer.
+- `labels`: value-added services labels on order level.
+- `documents`: contain meta data, objectId or url, of attached documents by the
+  buyer. See:
 
 {% page-ref page="download-document.md" %}
 
-* `orderType`: the order type, one of `Purchase`, `Forecast` or `RFQ`. Default `Purchase`.
+- `orderType`: the order type, one of `Purchase`, `Forecast` or `RFQ`. Default
+  `Purchase`.
 
 ### Supplier order
 
-`supplierOrder` is mostly an echo of your order fields as explained in [Send order response](../send-order-response/)​.
+`supplierOrder` is mostly an echo of your order fields as explained in
+[Send order response](../send-order-response/)​.
 
-* `buyerAccountNumber`: the buyer account number as known in your ERP system.
+- `buyerAccountNumber`: the buyer account number as known in your ERP system.
 
 {% hint style="warning" %}
-The `buyerAccountNumber` should be set on forehand in the Tradecloud connection with your buyer. You can set the account code when inviting a new connection or in the connection overview in the portal.
+The `buyerAccountNumber` should be set on forehand in the Tradecloud connection
+with your buyer. You can set the account code when inviting a new connection or
+in the connection overview in the portal.
 {% endhint %}
 
 ### Order status
 
-The order status is the aggregation of all the lines statuses. See [Order status](../../status.md#order-status) for the complete list of values.
+The order status is the aggregation of all the lines statuses. See
+[Order status](../../status.md#order-status) for the complete list of values.
 
 ## `singleDeliveryOrderEvent` lines
 
 `lines` contains one or more order lines:
 
-* `id`: the Tradecloud line identifier
-* `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
-* `supplierLine`: the supplier part of the order line, see [Supplier line](#supplier-line).
-* `confirmedLine`: the order line as agreed between buyer and supplier.
-* `statusLine`: the order line values representing the current `Issued`, `Confirmed` or `InProgess` status, see [Status line](#status-line).
-* `indicators.deliveryOverdue` is true when the order line is overdue.
-* `status.processStatus`: the order line's [Line process status](../../status.md#line-process-status).
-* `status.inProgressStatus` the order line's [Line in progress status](../../status.md#line-in-progress-status).
-* `status.logisticsStatus`: the order line's [Line logistics status](../../status.md#line-logistics-status).
-* `eventDates`: some key line event date/times
-* `mergedItemDetails`: detailed part information provided by both buyer and supplier, see [Item details](#item-details).
-* `lastUpdatedAt`: is the latest date time the order line has been changed.
+- `id`: the Tradecloud line identifier
+- `buyerLine`: the buyer part of the order line, see [Buyer line](#buyer-line).
+- `supplierLine`: the supplier part of the order line, see [Supplier
+  line](#supplier-line).
+- `confirmedLine`: the order line as agreed between buyer and supplier.
+- `statusLine`: the order line values representing the current `Issued`,
+  `Confirmed` or `InProgess` status, see [Status line](#status-line).
+- `indicators.deliveryOverdue` is true when the order line is overdue.
+- `status.processStatus`: the order line's [Line process
+  status](../../status.md#line-process-status).
+- `status.inProgressStatus` the order line's [Line in progress
+  status](../../status.md#line-in-progress-status).
+- `status.logisticsStatus`: the order line's [Line logistics
+  status](../../status.md#line-logistics-status).
+- `eventDates`: some key line event date/times
+- `mergedItemDetails`: detailed part information provided by both buyer and
+  supplier, see [Item details](#item-details).
+- `lastUpdatedAt`: is the latest date time the order line has been changed.
 
 ### Buyer line
 
 `buyerLine` contains the buyer order line fields:
 
-* `position`: the line position within the purchase order
-* `description`: a free format additional description of this line
-* `item`: the item (or article, goods) to be delivered, see [Item](#item)
-* `requests`: the buyer can request different delivery schedule, prices and charge lines. Advised is to use the `statusLine.deliveryScheduleInclRequests` and `statusLine.pricesInclRequests` fields instead.
-* `terms`: the line terms as agreed with your buyer
-  * `contractNumber`: the agreed framework contract number
-  * `contractPosition`: the related position within the framework contract
-* `projectNumber`: The buyer's project number reference
-* `productionNumber`:  The buyer's production number reference
-* `salesOrderNumber`:  The buyer's sales order number \(not be confused with your sales order number\)
-* `indicators.noDeliveryExpected`: No goods are expected to be delivered to the buyer, for example a service, fee or text line.
-* `indicators.delivered`: All goods are delivered at the buyer.
-* `properties`: are key-value based custom fields. `\n` may be used for a new line in the value.
-* `notes`: are simple custom fields. `\n` may be used for a new line.
-* `labels`: value-added services labels on line level.
-* `documents`: contain meta data and link of attached documents, see:
+- `position`: the line position within the purchase order
+- `lineType`: `Item`, `Service`, or `Charge` — **always present** when you
+  receive the order. If the buyer omitted `lineType` when issuing, the value is
+  **`Item`**.
+- `chargeReasonCode`: optional — UNCL7161 code when the buyer set a charge
+  reason on the line
+- `description`: a free format additional description of this line
+- `item`: the item (or article, goods) to be delivered, see [Item](#item)
+- `requests`: the buyer can request different delivery schedule and prices.
+  Advised is to use the `statusLine.deliveryScheduleInclRequests` and
+  `statusLine.pricesInclRequests` fields instead.
+- `terms`: the line terms as agreed with your buyer
+  - `contractNumber`: the agreed framework contract number
+  - `contractPosition`: the related position within the framework contract
+- `projectNumber`: The buyer's project number reference
+- `productionNumber`:  The buyer's production number reference
+- `salesOrderNumber`: The buyer's sales order number \(not be confused with your
+  sales order number\)
+- `indicators.noDeliveryExpected`: No goods are expected to be delivered to the
+  buyer, for example a service, fee or text line.
+- `indicators.delivered`: All goods are delivered at the buyer.
+- `properties`: are key-value based custom fields. `\n` may be used for a new
+  line in the value.
+- `notes`: are simple custom fields. `\n` may be used for a new line.
+- `labels`: value-added services labels on line level.
+- `documents`: contain meta data and link of attached documents, see:
 
 {% page-ref page="download-document.md" %}
+
+{% hint style="info" %}
+See [Order line type](../../line-type.md).
+{% endhint %}
 
 #### Item
 
 `lines.buyerLine.item`: The item (or article, goods) to be delivered.
 
-* `number`: the item code or number as known in the buyer ERP system.
-* `revision`: the revision (or version) of this item number
-* `name`: the item short name
-* `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`
-* `supplierItemNumber`: the item code or number as known at the supplier.
+- `number`: the item code or number as known in the buyer ERP system.
+- `revision`: the revision (or version) of this item number
+- `name`: the item short name
+- `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a
+  typical example is `PCE`
+- `supplierItemNumber`: the item code or number as known at the supplier.
 
 ### Supplier line
 
-`supplierLine` is an echo of your order line fields as explained in [Send order response](../send-order-response/)​.
+`supplierLine` is an echo of your order line fields as explained in
+[Send order response](../send-order-response/)​.
 
 ### Status line
 
-`lines.statusLine` represents the current order line values related to the current `Issued`, `Confirmed` or `InProgress` process status. The `InclRequests` fields also include the `InProgress` status and related open buyer or supplier request values.
+`lines.statusLine` represents the current order line values related to the
+current `Issued`, `Confirmed` or `InProgress` process status. The `InclRequests`
+fields also include the `InProgress` status and related open buyer or supplier
+request values.
 
 #### Single delivery
 
-When using `singleDeliveryOrderEvent` one single delivery per order line is used:
+When using `singleDeliveryOrderEvent` one single delivery per order line is
+used:
 
-* `lines.statusLine.scheduledDelivery`: the current delivery line, either having `Issued` or `Confirmed` values.
-* `lines.statusLine.scheduledDeliveryInclRequests`: the current delivery line, either having `Issued`, `InProgress` requests or `Confirmed` values.
+- `lines.statusLine.scheduledDelivery`: the current delivery line, either having
+  `Issued` or `Confirmed` values.
+- `lines.statusLine.scheduledDeliveryInclRequests`: the current delivery line,
+  either having `Issued`, `InProgress` requests or `Confirmed` values.
 
 ##### Scheduled delivery fields
 
-* `lines.statusLine.scheduledDelivery[InclRequests].date`: the delivery date of this delivery line. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
-* `lines.statusLine.scheduledDelivery[InclRequests].quantity`: the quantity of this delivery line. Quantity has a decimal `1234.56` format with any number of digits.
+- `lines.statusLine.scheduledDelivery[InclRequests].date`: the delivery date of
+  this delivery line. Date has ISO 8601 date `yyyy-MM-dd` format. See also
+  [Standards](../../api/standards.md).
+- `lines.statusLine.scheduledDelivery[InclRequests].quantity`: the quantity of
+  this delivery line. Quantity has a decimal `1234.56` format with any number of
+  digits.
 
 ##### Scheduled delivery logistics fields
 
-These additional logistics fields are only available in the status line scheduled delivery:
+These additional logistics fields are only available in the status line
+scheduled delivery:
 
-* `lines.statusLine.scheduledDelivery[InclRequests].status`: the optional delivery line's [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status).
-* `lines.statusLine.scheduledDelivery[InclRequests].etd`: The optional logistics Estimated Time of Departure \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
-* `lines.statusLine.scheduledDelivery[InclRequests].eta`: The optional logistics Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601 date `yyyy-MM-dd` format.
+- `lines.statusLine.scheduledDelivery[InclRequests].status`: the optional
+  delivery line's [Scheduled delivery logistics status](../../status.md#scheduled-delivery-logistics-status).
+- `lines.statusLine.scheduledDelivery[InclRequests].etd`: The optional logistics
+  Estimated Time of Departure \(local date without time zone\). Date has ISO
+  8601 date `yyyy-MM-dd` format.
+- `lines.statusLine.scheduledDelivery[InclRequests].eta`: The optional logistics
+  Estimated Time of Arrival \(local date without time zone\). Date has ISO 8601
+  date `yyyy-MM-dd` format.
 
 #### Prices
 
-* `lines.statusLine.prices`: the current prices, either having `Issued` or `Confirmed` values.
-* `lines.statusLine.pricesInclRequests`: the current delivery line, either having `Issued`, `InProgress` requests or `Confirmed` values.
+- `lines.statusLine.prices`: the current prices, either having `Issued` or
+  `Confirmed` values.
+- `lines.statusLine.pricesInclRequests`: the current delivery line, either
+  having `Issued`, `InProgress` requests or `Confirmed` values.
 
 ##### Prices fields
 
-* `lines.statusLine.prices[InclRequests].grossPrice`: the gross price. Used together with `discountPercentage`.
-* `lines.statusLine.prices[InclRequests].discountPercentage`: the discount percentage. Used together with `grossPrice`.
-* `lines.statusLine.prices[InclRequests].netPrice`: the net price.
-  * `priceInTransactionCurrency`: the price in the transaction currency of the supplier, like `CNY` in China.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`, `USD` and `CNY`
-  * `priceInBaseCurrency`: the price in your base currency, like `EUR` in the EU.
-    * `value`: the price value has a decimal `1234.56` format with any number of digits.
-    * `currencyIso`: the 3-letter currency code according to ISO 4217, like `EUR`.
-* `lines.statusLine.prices[InclRequests].priceUnitOfMeasureIso`: the 3-letter price unit according to ISO 80000-1. The purchase unit and price unit may be different.
-* `lines.statusLine.prices[InclRequests].priceUnitQuantity`: the item quantity at which the price applies. Typically this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
+- `lines.statusLine.prices[InclRequests].grossPrice`: the gross price. Used
+  together with `discountPercentage`.
+- `lines.statusLine.prices[InclRequests].discountPercentage`: the discount
+  percentage. Used together with `grossPrice`.
+- `lines.statusLine.prices[InclRequests].netPrice`: the net price.
+  - `priceInTransactionCurrency`: the price in the transaction currency of the
+    supplier, like `CNY` in China.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`, `USD` and `CNY`
+  - `priceInBaseCurrency`: the price in your base currency, like `EUR` in the
+    EU.
+    - `value`: the price value has a decimal `1234.56` format with any number
+      of digits.
+    - `currencyIso`: the 3-letter currency code according to ISO 4217, like
+      `EUR`.
+- `lines.statusLine.prices[InclRequests].priceUnitOfMeasureIso`: the 3-letter
+  price unit according to ISO 80000-1. The purchase unit and price unit may be
+  different.
+- `lines.statusLine.prices[InclRequests].priceUnitQuantity`: the item quantity
+  at which the price applies. Typically this is 1 \(unit price\) or 100 \(the
+  price applies to 100 items\)
 
 {% hint style="info" %}
-It is advised to only use `netPrice` for its simplicity, or alternatively use `grossPrice` together with `discountPercentage`.
+It is advised to only use `netPrice` for its simplicity, or alternatively use
+`grossPrice` together with `discountPercentage`.
 {% endhint %}
 
 ### Line status
 
-See [Line status](../../status.md#line-status) for the complete list of line process, in progress and logistics status values.
+See [Line status](../../status.md#line-status) for the complete list of line
+process, in progress and logistics status values.
 
 ### Item details
 
 {% hint style="info" %}
 The buyer may send item details to inform the supplier about part information.  
-The supplier may check, change and add item details if they are not correct or incomplete.  
-`lines.mergedItemDetails` will contain the original item details added by the buyer merged with the changed or added item details by the supplier.
+The supplier may check, change and add item details if they are not correct or
+incomplete.
+`lines.mergedItemDetails` will contain the original item details added by the
+buyer merged with the changed or added item details by the supplier.
 {% endhint %}
 
-* `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture, production, or growth where an article or product comes from.
-* `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the requirements both of the Common Customs Tariff and of the EU's external trade statistics.
-* `netWeight`: Net weight of one item.
-* `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
-* `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that identify dangerous goods, hazardous substances and articles in the framework of international transport.
-* `serialNumber`: is an unique identifier assigned incrementally or sequentially to an item, to uniquely identify it.
-* `batchNumber`: is an identification number assigned to a particular quantity or lot of material from a single manufacturer
+- `countryOfOriginCodeIso2`: The ISO 3166-1 alpha-2 country code of manufacture,
+  production, or growth where an article or product comes from.
+- `combinedNomenclatureCode`: A tool for classifying goods, set up to meet the
+  requirements both of the Common Customs Tariff and of the EU's external trade
+  statistics.
+- `netWeight`: Net weight of one item.
+- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
+  identify dangerous goods, hazardous substances and articles in the framework
+  of international transport.
+- `serialNumber`: is an unique identifier assigned incrementally or sequentially
+  to an item, to uniquely identify it.
+- `batchNumber`: is an identification number assigned to a particular quantity
+  or lot of material from a single manufacturer

--- a/order/supplier/reopen.md
+++ b/order/supplier/reopen.md
@@ -4,36 +4,52 @@ description: How to request the buyer to reopen an order or line
 
 # Reopen an order
 
-If an order line is **confirmed** (buyer and supplier agreed on delivery schedule, prices and related fields), the supplier can **reopen** it to propose different values. Tradecloud creates a line-level reopen workflow task that the buyer can **approve** or **reject**.
+If an order line is **confirmed** (buyer and supplier agreed on delivery
+schedule, prices and related fields), the supplier can **reopen** it to propose
+different values. Tradecloud creates a line-level reopen workflow task that the
+buyer can **approve** or **reject**.
 
 ## When a reopen request is created
 
-When you send an order response update and the **responded** `delivery schedule`, `prices` and/or `charge lines` are **not equal** to the **confirmed** `delivery schedule`, `prices` and `charge lines`, Tradecloud automatically creates a reopen workflow task for the **buyer**.
+When you send an order response update and the **responded** `delivery schedule`
+and `prices` are **not equal** to the **confirmed** `delivery schedule` and
+`prices`, Tradecloud automatically creates a reopen workflow task for the
+**buyer**.
 
 When possible, provide the supplier line `reason` field.
 
 ## Update a reopen request that is in progress
 
-You may **change an open reopen request** by sending another order response update (new responded values that still differ from confirmed).
+You may **change an open reopen request** by sending another order response
+update (new responded values that still differ from confirmed).
 
 {% page-ref page="send-order-response/" %}
 
 ## Revert a reopen request
 
-You can **withdraw** an open reopen request **without** waiting for the buyer to approve or reject it.
+You can **withdraw** an open reopen request **without** waiting for the buyer
+to approve or reject it.
 
-Send an order response where the **responded** `delivery schedule`, `prices` and `charge lines` are **equal** to the **confirmed** `delivery schedule`, `prices` and `charge lines` — i.e. you align your response with what was already agreed before the reopen.
+Send an order response where the **responded** `delivery schedule` and `prices`
+are **equal** to the **confirmed** `delivery schedule` and `prices` — i.e. you
+align your response with what was already agreed before the reopen.
 
-In that case there is nothing left to negotiate: Tradecloud **reverts** the reopen workflow instead of keeping the line in negotiation. The line can return to process status `Confirmed` and the line-level [`inProgressStatus`](../status.md#line-in-progress-status) is cleared.
+In that case there is nothing left to negotiate: Tradecloud **reverts** the
+reopen workflow instead of keeping the line in negotiation. The line can return
+to process status `Confirmed` and the line-level
+[`inProgressStatus`](../status.md#line-in-progress-status) is cleared.
 
-This is **not** the same as the buyer rejecting the reopen; you are explicitly matching the last confirmed agreement.
+This is **not** the same as the buyer rejecting the reopen; you are explicitly
+matching the last confirmed agreement.
 
-Webhook subscribers receive [`OrderLinesReopenRequestRevertedBySupplier`](../../../connectors/webhooks/order-events.md#order-reopen-request-by-supplier).
+Webhook subscribers receive
+[`OrderLinesReopenRequestRevertedBySupplier`](../../../connectors/webhooks/order-events.md#order-reopen-request-by-supplier).
 
 {% hint style="warning" %}
 This is a **request** to the buyer to reopen an already confirmed order line.
 
-The buyer has to **approve** the reopen request before Tradecloud accepts a **change** that still differs from the confirmed values.
+The buyer has to **approve** the reopen request before Tradecloud accepts a
+**change** that still differs from the confirmed values.
 {% endhint %}
 
 {% hint style="warning" %}
@@ -41,5 +57,6 @@ You cannot reopen a `Completed` or `Cancelled` line.
 {% endhint %}
 
 {% hint style="info" %}
-An order line with process status `Confirmed` becomes `InProgress` when a reopen request is open. See [Line process status](../status.md#line-process-status).
+An order line with process status `Confirmed` becomes `InProgress` when a reopen
+request is open. See [Line process status](../status.md#line-process-status).
 {% endhint %}

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -9,18 +9,23 @@ As a supplier, you can send a purchase order response to your buyer.
 {% hint style="warning" %}
 Each order response **must** contain **one or more order lines**.
 
-The order response should only contain **order lines** that are **new or changed**.
+The order response should only contain **order lines** that are **new or
+changed**.
 {% endhint %}
 
 ## Order process
 
 As a supplier, you have three possible ways to respond to an order:
 
-1. **Detailed response**: Send an order response with lines containing their position, confirmed delivery schedule, prices, and optionally charge lines
-2. **Line-level acceptance**: Send an order response with lines containing their position and line-level accept or reject indicators
-3. **Header-level acceptance**: Send an order response with header-level accept or reject indicators, and lines containing only their positions
+1. **Detailed response**: Send an order response with lines containing their
+   position, confirmed delivery schedule, and prices
+2. **Line-level acceptance**: Send an order response with lines containing
+   their position and line-level accept or reject indicators
+3. **Header-level acceptance**: Send an order response with header-level accept
+   or reject indicators, and lines containing only their positions
 
-After sending an order response, the order line process status may change based on the current status:
+After sending an order response, the order line process status may change based
+on the current status:
 
 ### Status: Issued
 
@@ -30,7 +35,8 @@ The order line will become:
   - The `accepted` indicator is set, OR
   - Responded delivery schedule and prices match the requested values
 - `Rejected` if the `rejected` indicator is set
-- `InProgress` if responded values differ from requested values (creates a proposal task for the buyer)
+- `InProgress` if responded values differ from requested values (creates a
+  proposal task for the buyer)
 
 ### Status: InProgress
 
@@ -39,7 +45,9 @@ The order line will become:
 - `Confirmed` if:
   - The `accepted` indicator is set, OR
   - Responded delivery schedule and prices match the requested values, OR
-  - The line has an open supplier reopen request and responded values match the **confirmed** values again (reverts the reopen) — see [Revert a reopen request](../reopen.md#revert-a-reopen-request)
+  - The line has an open supplier reopen request and responded values match the
+    **confirmed** values again (reverts the reopen) — see [Revert a reopen
+    request](../reopen.md#revert-a-reopen-request)
 - `Rejected` if the `rejected` indicator is set
 - Stays `InProgress` if responded values still differ from requested values
 
@@ -47,7 +55,8 @@ The order line will become:
 
 The order line will:
 
-- Become `InProgress` if responded values differ from confirmed values (creates a reopen request task for the buyer)
+- Become `InProgress` if responded values differ from confirmed values
+  (creates a reopen request task for the buyer)
 - Stay `Confirmed` if responded values match the confirmed values
 
 ### Status: Completed or Cancelled
@@ -56,9 +65,11 @@ The process status will **not** change.
 
 ## Endpoint
 
+<!-- markdownlint-disable-next-line MD013 -->
 Use the [Send order response](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/supplier-endpoints/sendOrderResponseBySupplierRoute) endpoint to send an order response to Tradecloud.
 
-HTTP status code **200** or **202** means the order response was successfully verified or queued.
+HTTP status code **200** or **202** means the order response was successfully
+verified or queued.
 
 Processing typically takes less than a second, after which:
 
@@ -85,11 +96,11 @@ Processing typically takes less than a second, after which:
 - `description`: additional description of this order
 - `indicators.accepted`: accept all lines in this response as‑is.
   - Order lines with positions are required.
-  - Delivery schedule, prices, and charge lines will be ignored for these lines
+  - Delivery schedule and prices will be ignored for these lines
   - Line‑level indicators override this header indicator when present
 - `indicators.rejected`: reject all lines in this response
   - Order lines with positions are required.
-  - Delivery schedule, prices, and charge lines will be ignored for these lines
+  - Delivery schedule and prices will be ignored for these lines
   - Line‑level indicators override this header indicator when present
 - `properties`: key-value custom fields
   - use `\n` for new lines
@@ -121,7 +132,8 @@ At least one delivery schedule line is required:
 
 ### Responded prices
 
-**Recommended:** Use `netPrice` for simplicity, or use `grossPrice` + `discountPercentage`.
+**Recommended:** Use `netPrice` for simplicity, or use `grossPrice` +
+`discountPercentage`.
 
 - `netPrice` OR `grossPrice` + `discountPercentage`:
   - `priceInTransactionCurrency`: **required**
@@ -137,12 +149,19 @@ At least one delivery schedule line is required:
 
 ### Responded charge lines
 
-Additional costs independent of order line prices (e.g., transport, packing, inspection):
+{% hint style="warning" %}
+**Deprecated.** Charge lines (`chargeLines`) are deprecated. The following is
+retained for existing integrations only.
+{% endhint %}
+
+Additional costs independent of order line prices (e.g., transport, packing,
+inspection):
 
 - `position`: identifier for the charge line
   - Echo the `position` from the buyer, OR
   - Omit for new charge lines - the buyer will assign it
-- `chargeTypeCode`: **required** - charge reason code ([UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/))
+- `chargeTypeCode`: **required** - charge reason code
+  ([UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/))
 - `chargeDescription`: **required** - text description (e.g., "Transport costs")
 - `quantity`: **required** - quantity for this charge
 - `price`: **required**
@@ -158,9 +177,9 @@ Additional costs independent of order line prices (e.g., transport, packing, ins
 
 - `description`: additional description of this line
 - `indicators.accepted`: accept the line as-is
-  - Delivery schedule, prices, charge lines, and header indicators are ignored
+  - Delivery schedule, prices, and header indicators are ignored
 - `indicators.rejected`: reject the line
-  - Delivery schedule, prices, charge lines, and header indicators are ignored
+  - Delivery schedule, prices, and header indicators are ignored
 - `reason`: explanation when:
   - The line is rejected
   - Responded values differ from requested or confirmed values
@@ -179,10 +198,12 @@ If you need this feature, send a request to support.
 
 ### Item Details
 
-You can check, change, or add item details if the buyer's information is incorrect or incomplete:
+You can check, change, or add item details if the buyer's information is
+incorrect or incomplete:
 
 - `countryOfOriginCodeIso2`: ISO 3166-1 alpha-2 country code of origin
-- `combinedNomenclatureCode`: goods classification code for customs and trade statistics
+- `combinedNomenclatureCode`: goods classification code for customs and trade
+  statistics
 - `netWeight`: net weight of one item
 - `netWeightUnitOfMeasureIso`: net weight unit
 - `dangerousGoodsCodeUnece`: UN number for dangerous goods (4-digit)
@@ -191,5 +212,7 @@ You can check, change, or add item details if the buyer's information is incorre
 
 ## Order response metadata
 
-- `erpResponseDateTime`: date/time the order was responded in your ERP (ISO 8601 format: `yyyy-MM-ddTHH:mm:ss`)
-- `erpRespondedBy`: email or username of the person who responded to this order in your ERP
+- `erpResponseDateTime`: date/time the order was responded in your ERP (ISO 8601
+  format: `yyyy-MM-ddTHH:mm:ss`)
+- `erpRespondedBy`: email or username of the person who responded to this order
+  in your ERP

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -65,7 +65,6 @@ The process status will **not** change.
 
 ## Endpoint
 
-<!-- markdownlint-disable-next-line MD013 -->
 Use the [Send order response](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/supplier-endpoints/sendOrderResponseBySupplierRoute) endpoint to send an order response to Tradecloud.
 
 HTTP status code **200** or **202** means the order response was successfully
@@ -150,28 +149,9 @@ At least one delivery schedule line is required:
 ### Responded charge lines
 
 {% hint style="warning" %}
-**Deprecated.** Charge lines (`chargeLines`) are deprecated. The following is
-retained for existing integrations only.
+**Deprecated.** Charge lines (`chargeLines`) are deprecated. Superseded by
+`lineType` `Charge` and line-level pricing, see [Order line type](../../line-type.md).
 {% endhint %}
-
-Additional costs independent of order line prices (e.g., transport, packing,
-inspection):
-
-- `position`: identifier for the charge line
-  - Echo the `position` from the buyer, OR
-  - Omit for new charge lines - the buyer will assign it
-- `chargeTypeCode`: **required** - charge reason code
-  ([UNCL7161](https://docs.peppol.eu/poacc/upgrade-3/codelist/UNCL7161/))
-- `chargeDescription`: **required** - text description (e.g., "Transport costs")
-- `quantity`: **required** - quantity for this charge
-- `price`: **required**
-  - `priceInTransactionCurrency`: **required**
-    - `value`: decimal format (e.g., `1234.56`)
-    - `currencyIso`: 3-letter ISO 4217 code (e.g., `EUR`, `USD`, `CNY`)
-  - `priceInBaseCurrency`: optional
-    - `value`: decimal format
-    - `currencyIso`: 3-letter ISO 4217 code
-- `priceUnitOfMeasureIso`: price unit
 
 ### Other line fields
 


### PR DESCRIPTION
## Description
<!-- To be filled by PR submitter. Also provide a brief summary of the changes if needed -->
https://tradecloud.atlassian.net/browse/TC-10978

### Scope
This PR 
- adds line `lineType` and `chargeReasonCode`
- deprecated line `chargeLines`
- makes markdownlint happy for touched files.

### Submitter pre-flight check
<!-- To be filled by PR submitter (delete not applicable items) -->
- [ ] Review your documentation
- [ ] Add labels `needs reviewing`
- [ ] Assign PR and JIRA ticket to 'Reviewer' (in 'Reviewing' state)

### Reviewer pre-flight check
<!-- To be filled by PR reviewer (delete not applicable items) -->
- [ ] Review documentation in PR
- [ ] Remove label `needs reviewing`
- [ ] Merge the PR and remove the release for this branch from Gitbook
- [ ] Set Jira ticket to 'Released'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added order line type documentation (Item, Service, Charge) with guidance for modeling charges as separate lines

* **Documentation**
  * Expanded and restructured buyer & supplier order workflows, responses, item details, and status-transition guidance
  * Added single-delivery order guidance and clarified polling/webhook usage and lastUpdatedAt handling
  * Deprecation: removed nested chargeLines in favor of line-type/line-level pricing; removed chargeLines from reopen/update rules

* **Chores**
  * Added markdown linting configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tradecloud/tradecloud-docs-api-v2/pull/113)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->