### PR TITLE
docs: [TC-11065] unit-of-measure as-is handling with optional UN/ECE Rec 20

### DIFF
--- a/api/standards.md
+++ b/api/standards.md
@@ -10,7 +10,10 @@ Your integration **must support** these standards.
 
 ## Basic authentication
 
-[Basic authentication](https://swagger.io/docs/specification/authentication/basic-authentication/) is a simple HTTP authentication scheme built into the HTTP protocol. The client sends HTTPS requests with the Authorization header that contains the word `Basic` followed by a space and a base64-encoded string username:password
+[Basic authentication](https://swagger.io/docs/specification/authentication/basic-authentication/)
+is a simple HTTP authentication scheme built into the HTTP protocol. The client
+sends HTTPS requests with the Authorization header that contains the word
+`Basic` followed by a space and a base64-encoded string username:password
 
 Published as [RFC 7617 "The 'Basic' HTTP Authentication Scheme"](https://datatracker.ietf.org/doc/html/rfc7617)
 
@@ -18,36 +21,48 @@ Basic authentication is supported by both the API v2.0 and webhooks.
 
 ## Bearer authentication
 
-[Bearer authentication](https://swagger.io/docs/specification/authentication/bearer-authentication/) is an HTTP authentication scheme that involves security tokens called bearer tokens. The client send HTTPS requests with the `Authorization` header that contains the word `Bearer` followed by a space and the token.
+[Bearer authentication](https://swagger.io/docs/specification/authentication/bearer-authentication/)
+is an HTTP authentication scheme that involves security tokens called bearer
+tokens. The client send HTTPS requests with the `Authorization` header that
+contains the word `Bearer` followed by a space and the token.
 
 Published as [RFC 6750 "The OAuth 2.0 Authorization Framework: Bearer Token Usage"](https://datatracker.ietf.org/doc/html/rfc6750)
 
 The bearer token is supported as part of [JWT](#jwt) by the API v2.0.
 
-The bearer token is supported as part of [OAuth](#oauth) and as static token by the webhooks.
+The bearer token is supported as part of [OAuth](#oauth) and as static token by
+the webhooks.
 
 ## HTTP 1.1 and 2.0
 
-The [Hypertext Transfer Protocol](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) is a stateless application-level protocol for distributed, collaborative, hypertext information systems.
+The [Hypertext Transfer Protocol](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)
+is a stateless application-level protocol for distributed, collaborative,
+hypertext information systems.
 
-HTTP 1.1. is published as [RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230) and RFC 7231 to 7237.
+HTTP 1.1. is published as [RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230)
+and RFC 7231 to 7237.
 
 HTTP 2.0 is published as [RFC 7540](https://datatracker.ietf.org/doc/html/rfc7540)
 
 ## ISO Date/Time
 
-Date/time values use [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date format `YYYY-MM-DD` or local date/time format `YYYY-MM-DDThh:mm:ss`
+Date/time values use [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date
+format `YYYY-MM-DD` or local date/time format `YYYY-MM-DDThh:mm:ss`
 
 Published as [ISO 8601-1:2019](https://www.iso.org/standard/70907.htm)
 
 ## JSON
 
-Tradecloud supports JSON and [XML](#xml). JavaScript Object Notation (JSON) is a lightweight, text-based, language-independent data interchange format.
+Tradecloud supports JSON and [XML](#xml). JavaScript Object Notation (JSON) is a
+lightweight, text-based, language-independent data interchange format.
 
-Published as [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) and [ECMA-404](https://www.ecma-international.org/publications/standards/Ecma-404.htm) [\(PDF\)](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)
+Published as [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) and
+[ECMA-404](https://www.ecma-international.org/publications/standards/Ecma-404.htm)
+[\(PDF\)](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)
 
 {% hint style="warning" %}
-The JSON syntax does not assign any significance to the **ordering** of name/value pairs.
+The JSON syntax does not assign any significance to the **ordering** of
+name/value pairs.
 
 Therefor **XML** based transformations **expecting ordering** will break.
 {% endhint %}
@@ -58,61 +73,118 @@ The Tradecloud [compatibility rules](compatibility.md) apply to the JSON usage.
 
 ## JWT
 
-[JSON Web Tokens](https://jwt.io/) are an open, industry standard [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519) method for representing claims securely between two parties.
+[JSON Web Tokens](https://jwt.io/) are an open, industry standard
+[RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519) method for
+representing claims securely between two parties.
 
 JWT is supported by the API v2 only (and not by the webhooks).
 
 ## Media Types
 
-Tradecloud supports a sub set of the [RFC 6838 Media Type Specifications](https://datatracker.ietf.org/doc/html/rfc6838).
+Tradecloud supports a sub set of the
+[RFC 6838 Media Type Specifications](https://datatracker.ietf.org/doc/html/rfc6838).
 
 ## OAuth
 
-[OAuth 2.0](https://swagger.io/docs/specification/authentication/oauth2/) is an authorization protocol that gives an API client limited access to user data on a web server. OAuth relies on authentication scenarios called flows, which allow the resource owner (user) to share the protected content from the resource server without sharing their credentials. For that purpose, an OAuth 2.0 server issues access tokens that the client applications can use to access protected resources on behalf of the resource owner.
+[OAuth 2.0](https://swagger.io/docs/specification/authentication/oauth2/) is an
+authorization protocol that gives an API client limited access to user data on a
+web server. OAuth relies on authentication scenarios called flows, which allow
+the resource owner (user) to share the protected content from the resource
+server without sharing their credentials. For that purpose, an OAuth 2.0 server
+issues access tokens that the client applications can use to access protected
+resources on behalf of the resource owner.
 
 Published as [RFC 6749 "The OAuth 2.0 Authorization Framework"](https://datatracker.ietf.org/doc/html/rfc6749)
 
-The [OAuth 2.0 Client Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) is supported by the order webhooks only (and not by the API v2 or shipment webhook at this moment). Order webhook OAuth uses the Microsoft Identity Platform (MSAL4J) — it is not a general-purpose OAuth 2.0 client for other identity providers.
+The [OAuth 2.0 Client Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)
+is supported by the order webhooks only (and not by the API v2 or shipment
+webhook at this moment). Order webhook OAuth uses the Microsoft Identity
+Platform (MSAL4J) -- it is not a general-purpose OAuth 2.0 client for other
+identity providers.
 
 ## OpenAPI
 
-The [OpenAPI Version 2.0 Specification \(OAS 2.0\)](https://swagger.io/specification/v2/) creates a RESTful interface for easily developing and consuming an API by effectively mapping all the resources and operations associated with it.
+The [OpenAPI Version 2.0 Specification \(OAS 2.0\)](https://swagger.io/specification/v2/)
+creates a RESTful interface for easily developing and consuming an API by
+effectively mapping all the resources and operations associated with it.
 
 ## REST
 
-[Representational state transfer \(REST\)](https://en.wikipedia.org/wiki/Representational_state_transfer%20) is not a standard but a software architectural style that defines a set of constraints to be used for creating Web services. The Tradecloud API additionally uses a command and query style.
+[Representational state transfer \(REST\)](https://en.wikipedia.org/wiki/Representational_state_transfer%20)
+is not a standard but a software architectural style that defines a set of
+constraints to be used for creating Web services. The Tradecloud API additionally
+uses a command and query style.
 
 ## TLS v1.2 and v1.3
 
-[Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security) is a cryptographic protocol designed to provide communications security over a computer network.
+[Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security)
+is a cryptographic protocol designed to provide communications security over a
+computer network.
 
 {% hint style="warning" %}
-The Tradecloud API only supports [TLS v1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.2) published as [RFC 5246](https://datatracker.ietf.org/doc/html/rfc5246) and [TLS v1.3](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.3) published as [RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446)
+The Tradecloud API only supports
+[TLS v1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.2)
+published as [RFC 5246](https://datatracker.ietf.org/doc/html/rfc5246) and
+[TLS v1.3](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.3)
+published as [RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446)
 {% endhint %}
 
 ## URI
 
-A Uniform Resource Identifier \(URI\) is a compact sequence of characters that identifies an abstract or physical resource.
+A Uniform Resource Identifier \(URI\) is a compact sequence of characters that
+identifies an abstract or physical resource.
 
-Published as [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) with [errata](https://www.rfc-editor.org/errata_search.php?rfc=3986).
+Published as [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) with
+[errata](https://www.rfc-editor.org/errata_search.php?rfc=3986).
 
 {% hint style="warning" %}
-[URLs](https://www.w3schools.com/tags/ref_urlencode.ASP) can only be sent over the Internet using the [ASCII character-set](https://www.w3schools.com/charsets/ref_html_ascii.asp).
+[URLs](https://www.w3schools.com/tags/ref_urlencode.ASP) can only be sent over
+the Internet using the
+[ASCII character-set](https://www.w3schools.com/charsets/ref_html_ascii.asp).
 
-Since URLs often contain characters outside the ASCII set, the URL has to be converted into a valid ASCII format. URL encoding replaces unsafe ASCII characters with a "%" followed by two hexadecimal digits. URLs cannot contain spaces. URL encoding normally replaces a space with a plus \(+\) sign or with %20.
+Since URLs often contain characters outside the ASCII set, the URL has to be
+converted into a valid ASCII format. URL encoding replaces unsafe ASCII
+characters with a "%" followed by two hexadecimal digits. URLs cannot contain
+spaces. URL encoding normally replaces a space with a plus \(+\) sign or with
+%20.
 {% endhint %}
 
 ## UTF-8
 
-ISO/IEC 10646-1 defines a large character set called the Universal Character Set \(UCS\) which encompasses most of the world's writing systems. The originally proposed encodings of the UCS, however, were not compatible with many current applications and protocols, and this has led to the development of UTF-8
+ISO/IEC 10646-1 defines a large character set called the Universal Character Set
+\(UCS\) which encompasses most of the world's writing systems. The originally
+proposed encodings of the UCS, however, were not compatible with many current
+applications and protocols, and this has led to the development of UTF-8
 
 Published as [RFC 9259](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1)
 
+## Units of Measure
+
+{% hint style="info" %}
+The "must support" requirement above does not apply to units of measure.
+{% endhint %}
+
+Buyers send units in their own convention; suppliers see them **as-is**. No
+standard is enforced, despite field names such as `purchaseUnitOfMeasureIso` or
+`unitOfMeasureUnece`. If you want a standard, we recommend
+[UN/ECE Recommendation N°20](https://unece.org/trade/uncefact/cl-recommendations),
+but it is not required.
+
+Exceptions to as-is handling:
+
+- the portal translates some human-unreadable units for display;
+- units are translated for the SCSN network;
+- Tradecloud treats equivalent buyer and supplier units as the same when
+  comparing values.
+
 ## XML
 
-Tradecloud supports XML and [JSON](#json). The [Extensible Markup Language](https://en.wikipedia.org/wiki/XML) its main purpose is serialization, i.e. transmitting arbitrary data.
+Tradecloud supports XML and [JSON](#json). The
+[Extensible Markup Language](https://en.wikipedia.org/wiki/XML) its main purpose
+is serialization, i.e. transmitting arbitrary data.
 
-Published as [Extensible Markup Language (XML) 1.0 (Fifth Edition)](https://www.w3.org/TR/REC-xml/)
+Published as
+[Extensible Markup Language (XML) 1.0 (Fifth Edition)](https://www.w3.org/TR/REC-xml/)
 
 {% hint style="warning" %}
 Tradecloud does not assign any significance to the **ordering** of XML tags.

--- a/forecast/issue.md
+++ b/forecast/issue.md
@@ -9,27 +9,36 @@ description: How to issue a forecast as a buyer
 As buyer you can send a new forecast to Tradecloud.
 
 {% hint style="info" %}
-A forecast cannot be updated. Issued forecasts will always be appended to the existing set of forecasts.
+A forecast cannot be updated. Issued forecasts will always be appended to the
+existing set of forecasts.
 {% endhint %}
 
 ## Endpoint
 
-Use the [Send forecast](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendForecastByBuyerRoute) endpoint to send a forecast to Tradecloud.
+Use the [Send
+forecast](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendForecastByBuyerRoute)
+endpoint to send a forecast to Tradecloud.
 
 {% hint style="info" %}
-When sending a forecast the provided supplier account number will be verified. 
+When sending a forecast the provided supplier account number will be verified.
 {% endhint %}
 
 ## Header
 
-* `companyId`: the optional Tradecloud company identifier. You only have to provide a companyId when your integration user account has authorization for multiple companies.
-* `supplierAccountNumber`: the supplier account number as known in your ERP system.
+* `companyId`: the optional Tradecloud company identifier. You only have to
+  provide a companyId when your integration user account has authorization for
+  multiple companies.
+* `supplierAccountNumber`: the supplier account number as known in your ERP
+  system.
 
 {% hint style="warning" %}
-The `supplierAccountNumber` must be set in the Tradecloud connection in the portal, after the connection request has been accepted.
+The `supplierAccountNumber` must be set in the Tradecloud connection in the
+portal, after the connection request has been accepted.
 {% endhint %}
 
-* `forecastNumber`: the mandatory forecast identifier, like code or number as known in your forecast or ERP system. The number must be the same for all items for all suppliers in the same generated forecast.
+* `forecastNumber`: the mandatory forecast identifier, like code or number as
+  known in your forecast or ERP system. The number must be the same for all
+  items for all suppliers in the same generated forecast.
 
 {% hint style="warning" %}
 The `forecastNumber` must not contain whitespace characters.
@@ -37,28 +46,41 @@ The `forecastNumber` must not contain whitespace characters.
 
 ## Lines
 
-`lines`: a forecast contains one or multiple lines. A forecast line consists of an item and forecast schedule. It is structured as a JSON element in the `lines` JSON array. 
+`lines`: a forecast contains one or multiple lines. A forecast line consists of
+  an item and forecast schedule. It is structured as a JSON element in the
+  `lines` JSON array.
 
 ### Item
 
 `lines.item`: the forecasted item \(or article, goods\).
 
-* `buyerItemNumber`: the mandatory item code or number as known in your ERP system.
+* `buyerItemNumber`: the mandatory item code or number as known in your ERP
+  system.
 * `buyerItemRevision`: the revision \(or version\) of this item number.
 * `buyerItemName`: the mandatory item short name.
-* `supplierItemNumber`: the item code or number as known at the supplier. Required in case of wholesale suppliers.
-* `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`.
+* `supplierItemNumber`: the item code or number as known at the supplier.
+  Required in case of wholesale suppliers.
+* `purchaseUnitOfMeasureIso`: the purchase unit of measure, passed through
+  as-is. No standard is enforced; UN/ECE Recommendation N°20 is recommended if
+  you want a standard. A typical example is `PCE`.
 
 {% hint style="warning" %}
-`buyerItemNumber` should be unique within your company and never change. Never renumber or re-use `buyerItemNumber`s.
+`buyerItemNumber` should be unique within your company and never change. Never
+renumber or re-use `buyerItemNumber`s.
 {% endhint %}
 
-`lines.schedule`: the forecast schedule lines for this item, each consisting of a forecast period and forecasted demand during this period. It is structured as a JSON element in the `schedule` JSON array. 
+`lines.schedule`: the forecast schedule lines for this item, each consisting of
+  a forecast period and forecasted demand during this period. It is structured
+  as a JSON element in the `schedule` JSON array.
 
-* `startDate`: the first day of this forecast period. Date has ISO 8601 date `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
+* `startDate`: the first day of this forecast period. Date has ISO 8601 date
+  `yyyy-MM-dd` format. See also [Standards](../../api/standards.md).
 * `endDate`: the last day of this forecast period.
-* `quantity`: the forecasted demand of this item, in this period, for this supplier. Quantity has a decimal `1234.56` format with any number of digits.
+* `quantity`: the forecasted demand of this item, in this period, for this
+  supplier. Quantity has a decimal `1234.56` format with any number of digits.
 
 ## issueDateTime
 
-* `issueDateTime`: Date and time the forecast was originally issued in your forecast or ERP system. `DateTime` has ISO 8601 local date/time format `yyyy-MM-ddThh:mm:ss`. See also [Standards](../../api/standards.md).
+* `issueDateTime`: Date and time the forecast was originally issued in your
+  forecast or ERP system. `DateTime` has ISO 8601 local date/time format
+  `yyyy-MM-ddThh:mm:ss`. See also [Standards](../../api/standards.md).

--- a/forecast/slimstock.md
+++ b/forecast/slimstock.md
@@ -2,34 +2,42 @@
 description: How to issue a forecast as a buyer using Slimstock
 ---
 
-# Issue a new Slimstock forecast 
+# Issue a new Slimstock forecast
 
 ## Forecast process
 
 As buyer you can send a new forecast from Slimstock to Tradecloud.
 
 {% hint style="info" %}
-A forecast cannot be updated. Issued forecasts will always be appended to the existing set of forecasts.
+A forecast cannot be updated. Issued forecasts will always be appended to the
+existing set of forecasts.
 {% endhint %}
 
 ## Endpoint
 
-Use the [Send Slimstock forecast](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendSlimstockForecastByBuyerRoute) endpoint to send a Slimstock forecast to Tradecloud.
+Use the [Send Slimstock
+forecast](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendSlimstockForecastByBuyerRoute)
+endpoint to send a Slimstock forecast to Tradecloud.
 
 {% hint style="info" %}
-When sending a forecast the provided supplier account number will be verified. 
+When sending a forecast the provided supplier account number will be verified.
 {% endhint %}
 
 ## Header
 
-* `companyId`: the optional Tradecloud company identifier. You only have to provide a companyId when your integration user account has authorization for multiple companies.
-* `supplierAccountNumber`: the supplier account number as known in your ERP system.
+* `companyId`: the optional Tradecloud company identifier. You only have to
+  provide a companyId when your integration user account has authorization for
+  multiple companies.
+* `supplierAccountNumber`: the supplier account number as known in your ERP
+  system.
 
 {% hint style="warning" %}
-The `supplierAccountNumber` must be set in the Tradecloud connection in the portal, after the connection request has been accepted.
+The `supplierAccountNumber` must be set in the Tradecloud connection in the
+portal, after the connection request has been accepted.
 {% endhint %}
 
-* `forecastNumber`: the mandatory forecast identifier in Slimstock. The number must be the same for each supplier forecast from the same generated forecast.
+* `forecastNumber`: the mandatory forecast identifier in Slimstock. The number
+  must be the same for each supplier forecast from the same generated forecast.
 
 {% hint style="warning" %}
 The `forecastNumber` must not contain whitespace characters.
@@ -37,21 +45,32 @@ The `forecastNumber` must not contain whitespace characters.
 
 ## Lines
 
-`lines`: a forecast contains one or multiple lines. A forecast line contains item information and up to 36 months of demand forecasts for this item.
+`lines`: a forecast contains one or multiple lines. A forecast line contains
+  item information and up to 36 months of demand forecasts for this item.
 
-* `buyerItemNumber`: the mandatory item code or number as known in Slimstock and your ERP.
+* `buyerItemNumber`: the mandatory item code or number as known in Slimstock and
+  your ERP.
 * `buyerItemRevision`: the revision \(or version\) of this item number.
 * `buyerItemName`: the mandatory item short name.
-* `supplierItemNumber`: the item code or number as known at the supplier. Required in case of wholesale suppliers.
-* `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a typical example is `PCE`.
-* `startDate`: the date at which the forecasts periods start. Only the month and year of this date are used (day of month is ignored).
-* `M0`: The forecasted demand for the 0th month, being the month of `startDate`. Quantity has a decimal `1234.56` format with any number of digits.
-* `M1` - `M35`: The forecasted demands for the consecutive months. Quantity has a decimal `1234.56` format with any number of digits.
+* `supplierItemNumber`: the item code or number as known at the supplier.
+  Required in case of wholesale suppliers.
+* `purchaseUnitOfMeasureIso`: the purchase unit of measure, passed through
+  as-is. No standard is enforced; UN/ECE Recommendation N°20 is recommended if
+  you want a standard. A typical example is `PCE`.
+* `startDate`: the date at which the forecasts periods start. Only the month and
+  year of this date are used (day of month is ignored).
+* `M0`: The forecasted demand for the 0th month, being the month of `startDate`.
+  Quantity has a decimal `1234.56` format with any number of digits.
+* `M1` - `M35`: The forecasted demands for the consecutive months. Quantity has
+  a decimal `1234.56` format with any number of digits.
 
 {% hint style="warning" %}
-`buyerItemNumber` should be unique within your company and never change. Never renumber or re-use `buyerItemNumber`s.
+`buyerItemNumber` should be unique within your company and never change. Never
+renumber or re-use `buyerItemNumber`s.
 {% endhint %}
 
 ## issueDateTime
 
-* `issueDateTime`: Date and time the forecast was originally issued in your forecast or ERP system. `DateTime` has ISO 8601 local date/time format `yyyy-MM-ddThh:mm:ss`. See also [Standards](../../api/standards.md).
+* `issueDateTime`: Date and time the forecast was originally issued in your
+  forecast or ERP system. `DateTime` has ISO 8601 local date/time format
+  `yyyy-MM-ddThh:mm:ss`. See also [Standards](../../api/standards.md).

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -152,8 +152,9 @@ See [Order line type](../../line-type.md) for a full overview.
 - `number`: the item code or number as known in your ERP
 - `revision`: the revision \(or version\) of this item number
 - `name`: the item short name
-- `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a
-  typical example is `PCE`
+- `purchaseUnitOfMeasureIso`: the purchase unit of measure, passed through as-is
+  to the supplier. No standard is enforced; UN/ECE Recommendation N°20 is
+  recommended if you want a standard. A typical example is `PCE`
 - `supplierItemNumber`: the item code or number as known at the supplier.
   Required in case of wholesale suppliers.
 
@@ -188,7 +189,9 @@ item details by the supplier.
   requirements both of the Common Customs Tariff and of the EU's external trade
   statistics.
 - `netWeight`: Net weight of one item.
-- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
+  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
+  a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.
@@ -231,8 +234,9 @@ its simplicity, used by most buyers, or alternatively `grossPrice` together with
       of digits.
     - `currencyIso`: the 3-letter currency code according to ISO 4217, like
       `EUR`.
-- `priceUnitOfMeasureIso`: the price unit according to ISO 80000-1. The purchase
-  unit and price unit may be different.
+- `priceUnitOfMeasureIso`: the price unit of measure, passed through as-is. No
+  standard is enforced; UN/ECE Recommendation N°20 is recommended if you want a
+  standard. The purchase unit and price unit may be different.
 - `priceUnitQuantity`: the item quantity at which the price applies. Typically
   this is 1 \(unit price\) or 100 \(the price applies to 100 items\)
 

--- a/order/buyer/issue/README.md
+++ b/order/buyer/issue/README.md
@@ -190,8 +190,8 @@ item details by the supplier.
   statistics.
 - `netWeight`: Net weight of one item.
 - `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
-  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
-  a standard.
+  Mandatory when netWeight is provided. No standard is enforced; UN/ECE
+  Recommendation N°20 is recommended if you want a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -304,9 +304,10 @@ values are returned, dependent on the line and request status.
       of digits.
     - `currencyIso`: the 3-letter currency code according to ISO 4217, like
       `EUR`.
-- `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the 3-letter price
-  unit according to ISO 80000-1. The purchase unit and price unit may be
-  different.
+- `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the price unit of
+  measure, passed through as-is. No standard is enforced; UN/ECE Recommendation
+  N°20 is recommended if you want a standard. The purchase unit and price unit
+  may be different.
 - `lines.prices[IncludingRequests].priceUnitQuantity`: the item quantity at
   which the price applies. Typically this is 1 \(unit price\) or 100 \(the price
   applies to 100 items\)
@@ -344,7 +345,9 @@ buyer merged with the changed or added item details by the supplier.
   requirements both of the Common Customs Tariff and of the EU's external trade
   statistics.
 - `netWeight`: Net weight of one item.
-- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
+  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
+  a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/buyer/receive/README.md
+++ b/order/buyer/receive/README.md
@@ -346,8 +346,8 @@ buyer merged with the changed or added item details by the supplier.
   statistics.
 - `netWeight`: Net weight of one item.
 - `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
-  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
-  a standard.
+  Mandatory when netWeight is provided. No standard is enforced; UN/ECE
+  Recommendation N°20 is recommended if you want a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -239,8 +239,8 @@ buyer merged with the changed or added item details by the supplier.
   statistics.
 - `netWeight`: Net weight of one item.
 - `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
-  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
-  a standard.
+  Mandatory when netWeight is provided. No standard is enforced; UN/ECE
+  Recommendation N°20 is recommended if you want a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/buyer/receive/single-delivery-order-response.md
+++ b/order/buyer/receive/single-delivery-order-response.md
@@ -204,9 +204,10 @@ scheduled delivery:
       of digits.
     - `currencyIso`: the 3-letter currency code according to ISO 4217, like
       `EUR`.
-- `lines.statusLine.prices[InclRequests].priceUnitOfMeasureIso`: the 3-letter
-  price unit according to ISO 80000-1. The purchase unit and price unit may be
-  different.
+- `lines.statusLine.prices[InclRequests].priceUnitOfMeasureIso`: the price unit
+  of measure, passed through as-is. No standard is enforced; UN/ECE
+  Recommendation N°20 is recommended if you want a standard. The purchase unit
+  and price unit may be different.
 - `lines.statusLine.prices[InclRequests].priceUnitQuantity`: the item quantity
   at which the price applies. Typically this is 1 \(unit price\) or 100 \(the
   price applies to 100 items\)
@@ -237,7 +238,9 @@ buyer merged with the changed or added item details by the supplier.
   requirements both of the Common Customs Tariff and of the EU's external trade
   statistics.
 - `netWeight`: Net weight of one item.
-- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
+  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
+  a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -369,8 +369,8 @@ buyer merged with the changed or added item details by the supplier.
   statistics.
 - `netWeight`: Net weight of one item.
 - `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
-  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
-  a standard.
+  Mandatory when netWeight is provided. No standard is enforced; UN/ECE
+  Recommendation N°20 is recommended if you want a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/supplier/receive/README.md
+++ b/order/supplier/receive/README.md
@@ -183,8 +183,9 @@ The order status is the aggregation of all the lines statuses. See
 - `number`: the item code or number as known in the buyer ERP system.
 - `revision`: the revision (or version) of this item number
 - `name`: the item short name
-- `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a
-  typical example is `PCE`
+- `purchaseUnitOfMeasureIso`: the purchase unit of measure, passed through as-is.
+  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
+  a standard. A typical example is `PCE`
 - `supplierItemNumber`: the item code or number as known at the supplier.
 
 {% hint style="warning" %}
@@ -325,9 +326,10 @@ values are returned, dependent on the line and request status.
       of digits.
     - `currencyIso`: the 3-letter currency code according to ISO 4217, like
       `EUR`.
-- `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the 3-letter price
-  unit according to ISO 80000-1. The purchase unit and price unit may be
-  different.
+- `lines.prices[IncludingRequests].priceUnitOfMeasureIso`: the price unit of
+  measure, passed through as-is. No standard is enforced; UN/ECE Recommendation
+  N°20 is recommended if you want a standard. The purchase unit and price unit
+  may be different.
 - `lines.prices[IncludingRequests].priceUnitQuantity`: the item quantity at
   which the price applies. Typically this is 1 \(unit price\) or 100 \(the price
   applies to 100 items\)
@@ -366,7 +368,9 @@ buyer merged with the changed or added item details by the supplier.
   requirements both of the Common Customs Tariff and of the EU's external trade
   statistics.
 - `netWeight`: Net weight of one item.
-- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
+  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
+  a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -154,8 +154,9 @@ The order status is the aggregation of all the lines statuses. See
 - `number`: the item code or number as known in the buyer ERP system.
 - `revision`: the revision (or version) of this item number
 - `name`: the item short name
-- `purchaseUnitOfMeasureIso`: the purchase unit according to ISO 80000-1, a
-  typical example is `PCE`
+- `purchaseUnitOfMeasureIso`: the purchase unit of measure, passed through as-is.
+  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
+  a standard. A typical example is `PCE`
 - `supplierItemNumber`: the item code or number as known at the supplier.
 
 ### Supplier line
@@ -229,9 +230,10 @@ scheduled delivery:
       of digits.
     - `currencyIso`: the 3-letter currency code according to ISO 4217, like
       `EUR`.
-- `lines.statusLine.prices[InclRequests].priceUnitOfMeasureIso`: the 3-letter
-  price unit according to ISO 80000-1. The purchase unit and price unit may be
-  different.
+- `lines.statusLine.prices[InclRequests].priceUnitOfMeasureIso`: the price unit
+  of measure, passed through as-is. No standard is enforced; UN/ECE
+  Recommendation N°20 is recommended if you want a standard. The purchase unit
+  and price unit may be different.
 - `lines.statusLine.prices[InclRequests].priceUnitQuantity`: the item quantity
   at which the price applies. Typically this is 1 \(unit price\) or 100 \(the
   price applies to 100 items\)
@@ -262,7 +264,9 @@ buyer merged with the changed or added item details by the supplier.
   requirements both of the Common Customs Tariff and of the EU's external trade
   statistics.
 - `netWeight`: Net weight of one item.
-- `netWeightUnitOfMeasureIso`: Net weight unit according to ISO 80000-1.
+- `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
+  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
+  a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/supplier/receive/single-delivery-order.md
+++ b/order/supplier/receive/single-delivery-order.md
@@ -265,8 +265,8 @@ buyer merged with the changed or added item details by the supplier.
   statistics.
 - `netWeight`: Net weight of one item.
 - `netWeightUnitOfMeasureIso`: Net weight unit of measure, passed through as-is.
-  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
-  a standard.
+  Mandatory when netWeight is provided. No standard is enforced; UN/ECE
+  Recommendation N°20 is recommended if you want a standard.
 - `dangerousGoodsCodeUnece`: UN numbers or UN IDs are four-digit numbers that
   identify dangerous goods, hazardous substances and articles in the framework
   of international transport.

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -65,14 +65,17 @@ The process status will **not** change.
 
 ## Endpoint
 
-Use the [Send order response](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/supplier-endpoints/sendOrderResponseBySupplierRoute) endpoint to send an order response to Tradecloud.
+Use the [Send order
+response](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/supplier-endpoints/sendOrderResponseBySupplierRoute)
+endpoint to send an order response to Tradecloud.
 
 HTTP status code **200** or **202** means the order response was successfully
 verified or queued.
 
 Processing typically takes less than a second, after which:
 
-- The provided buyer account number and purchase order number have been verified.
+- The provided buyer account number and purchase order number have been
+  verified.
 - The order response appears in the portal.
 - The response is forwarded to the buyer's ERP integration.
 
@@ -141,7 +144,9 @@ At least one delivery schedule line is required:
   - `priceInBaseCurrency`: optional
     - `value`: decimal format (e.g., `1234.56`)
     - `currencyIso`: 3-letter ISO 4217 code
-- `priceUnitOfMeasureIso`: price unit
+- `priceUnitOfMeasureIso`: price unit of measure, passed through as-is. No
+  standard is enforced; UN/ECE Recommendation N°20 is recommended if you want a
+  standard
   - Copied from buyer if empty
 - `priceUnitQuantity`: quantity at which price applies (typically `1` or `100`)
   - Copied from buyer if empty
@@ -150,7 +155,8 @@ At least one delivery schedule line is required:
 
 {% hint style="warning" %}
 **Deprecated.** Charge lines (`chargeLines`) are deprecated. Superseded by
-`lineType` `Charge` and line-level pricing, see [Order line type](../../line-type.md).
+`lineType` `Charge` and line-level pricing, see [Order line
+type](../../line-type.md).
 {% endhint %}
 
 ### Other line fields
@@ -185,7 +191,9 @@ incorrect or incomplete:
 - `combinedNomenclatureCode`: goods classification code for customs and trade
   statistics
 - `netWeight`: net weight of one item
-- `netWeightUnitOfMeasureIso`: net weight unit
+- `netWeightUnitOfMeasureIso`: net weight unit of measure, passed through as-is.
+  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
+  a standard
 - `dangerousGoodsCodeUnece`: UN number for dangerous goods (4-digit)
 - `serialNumber`: unique sequential identifier for the item
 - `batchNumber`: identification number for a quantity/lot from a manufacturer

--- a/order/supplier/send-order-response/README.md
+++ b/order/supplier/send-order-response/README.md
@@ -192,8 +192,8 @@ incorrect or incomplete:
   statistics
 - `netWeight`: net weight of one item
 - `netWeightUnitOfMeasureIso`: net weight unit of measure, passed through as-is.
-  No standard is enforced; UN/ECE Recommendation N°20 is recommended if you want
-  a standard
+  Mandatory when netWeight is provided. No standard is enforced; UN/ECE
+  Recommendation N°20 is recommended if you want a standard
 - `dangerousGoodsCodeUnece`: UN number for dangerous goods (4-digit)
 - `serialNumber`: unique sequential identifier for the item
 - `batchNumber`: identification number for a quantity/lot from a manufacturer

--- a/shipment/buyer/receive/README.md
+++ b/shipment/buyer/receive/README.md
@@ -25,47 +25,68 @@ For details on choosing between these methods:
 
 ### Using the webhook API
 
-Use the [POST shipment webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment-webhook-connector/specs.yaml#/shipment-webhook%20endpoints/webhookPost) endpoint.
+Use the [POST shipment
+webhook](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment-webhook-connector/specs.yaml#/shipment-webhook%20endpoints/webhookPost)
+endpoint.
 
 The webhook body contains:
 
-- `eventName`: Contains the [Shipment event name](../../../connectors/webhooks/shipment-events.md)
+- `eventName`: Contains the [Shipment event
+  name](../../../connectors/webhooks/shipment-events.md)
 - `shipment`: The actual shipment state
-- `meta`: The message meta information, see [Message meta information](#message-meta-information)
+- `meta`: The message meta information, see [Message meta
+  information](#message-meta-information)
 
 ### Using the polling API
 
-Use the [POST poll shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/pollShipmentsRoute) endpoint.
+Use the [POST poll
+shipments](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/shipment/specs.yaml#/shipment/pollShipmentsRoute)
+endpoint.
 
 The polling response body contains:
 
 - `data`: The actual shipment states
 - `total`: The total number of matching shipments, regardless of paging
-- `lastUpdatedAt`: Store the `lastUpdatedAt` value to use as `lastUpdatedAfter` in subsequent requests
+- `lastUpdatedAt`: Store the `lastUpdatedAt` value to use as `lastUpdatedAfter`
+  in subsequent requests
 
 ## Shipment state
 
 The shipment data includes:
 
 - `id`: The Tradecloud shipment identifier
-- `identifiers`: The identifiers related to this shipment, see [Shipment identifiers](#shipment-identifiers)
-- `transportMode`: The mode of transport name used for the delivery of goods. [UNECE Code List Recommendation 19](https://unece.org/trade/uncefact/cl-recommendations) is recommended for mode of transport names
-- `supplierShipment`: The supplier side header of the shipment, see [Supplier shipment header](#supplier-shipment-header)
-- `buyerShipment`: The buyer side header of the shipment, see [Buyer shipment header](#buyer-shipment-header)
-- `loadCarriers`: A list of all load carriers in this shipment, each containing shipment lines, see [Load carrier](#load-carrier)
-- `lines`: A list of all shipment lines not loaded in a load carrier, see [Shipment line](#shipment-line)
-- `locations`: The departure and destination locations with arrival and departure date/times, see [Shipment locations](#shipment-locations)
+- `identifiers`: The identifiers related to this shipment, see [Shipment
+  identifiers](#shipment-identifiers)
+- `transportMode`: The mode of transport name used for the delivery of goods.
+  [UNECE Code List Recommendation
+  19](https://unece.org/trade/uncefact/cl-recommendations) is recommended for
+  mode of transport names
+- `supplierShipment`: The supplier side header of the shipment, see [Supplier
+  shipment header](#supplier-shipment-header)
+- `buyerShipment`: The buyer side header of the shipment, see [Buyer shipment
+  header](#buyer-shipment-header)
+- `loadCarriers`: A list of all load carriers in this shipment, each containing
+  shipment lines, see [Load carrier](#load-carrier)
+- `lines`: A list of all shipment lines not loaded in a load carrier, see
+  [Shipment line](#shipment-line)
+- `locations`: The departure and destination locations with arrival and
+  departure date/times, see [Shipment locations](#shipment-locations)
 - `status`: The shipment status
-  - `processStatus`: The shipment process status, currently `Issued`, `Approved`, or `Rejected`, and may be extended with other values in the future
-  - `processStatusReason`: The optional reason for the current process status, for example why the shipment was rejected
-- `meta`: Meta information about the shipment, see [Shipment meta information](#shipment-meta-information)
+- `processStatus`: The shipment process status, currently `Issued`, `Approved`,
+or `Rejected`, and may be extended with other values in the future
+- `processStatusReason`: The optional reason for the current process status, for
+example why the shipment was rejected
+- `meta`: Meta information about the shipment, see [Shipment meta
+  information](#shipment-meta-information)
 
 ### Shipment identifiers
 
 The identifiers related to this shipment:
 
 - `billOfLadingNumber`: The bill of lading number as provided by the carrier
-- `imoNumber`: The IMO [ship identification number](https://www.imo.org/en/ourwork/msas/pages/imo-identification-number-scheme.aspx) as provided by the carrier
+- `imoNumber`: The IMO [ship identification
+  number](https://www.imo.org/en/ourwork/msas/pages/imo-identification-number-scheme.aspx)
+  as provided by the carrier
 - `carrierShipmentNumber`: The shipment number as provided by the carrier
 - `trackingNumber`: The tracking number as provided by the carrier or courier
 
@@ -74,23 +95,33 @@ The identifiers related to this shipment:
 The supplier side header of this shipment:
 
 - `companyId`: The mandatory Tradecloud company identifier of the supplier
-- `supplierParty`: The unique party identifier and scheme, like [GLN](https://www.gs1.org/standards/id-keys/gln), of the supplier
+- `supplierParty`: The unique party identifier and scheme, like
+  [GLN](https://www.gs1.org/standards/id-keys/gln), of the supplier
 - `buyerAccountNumber`: The buyer account code or number as used by the supplier
-- `shipmentNumber`: The related shipment number as known in the supplier's ERP system
-- `invoiceNumbers`: The related invoice numbers as known in the supplier's ERP system
-- `documents`: The supplier documents attached to this shipment, see [Document](#document)
-- `contacts`: The supplier contacts related to this shipment, see [Contact](#contact)
+- `shipmentNumber`: The related shipment number as known in the supplier's ERP
+  system
+- `invoiceNumbers`: The related invoice numbers as known in the supplier's ERP
+  system
+- `documents`: The supplier documents attached to this shipment, see
+  [Document](#document)
+- `contacts`: The supplier contacts related to this shipment, see
+  [Contact](#contact)
 
 ### Buyer shipment header
 
 The buyer side header of this shipment:
 
 - `companyId`: The mandatory Tradecloud company identifier of the buyer
-- `buyerParty`: The unique party identifier and scheme, like [GLN](https://www.gs1.org/standards/id-keys/gln), of the buyer
-- `supplierAccountNumber`: The supplier account code or number as known by the buyer
-- `documents`: The buyer documents attached to this shipment, see [Document](#document)
-- `contacts`: The buyer contacts related to this shipment, see [Contact](#contact)
-- `purchaseOrderTerms`: The purchase order terms as agreed between buyer and supplier, see [Purchase order terms](#purchase-order-terms)
+- `buyerParty`: The unique party identifier and scheme, like
+  [GLN](https://www.gs1.org/standards/id-keys/gln), of the buyer
+- `supplierAccountNumber`: The supplier account code or number as known by the
+  buyer
+- `documents`: The buyer documents attached to this shipment, see
+  [Document](#document)
+- `contacts`: The buyer contacts related to this shipment, see
+  [Contact](#contact)
+- `purchaseOrderTerms`: The purchase order terms as agreed between buyer and
+  supplier, see [Purchase order terms](#purchase-order-terms)
 
 #### Contact
 
@@ -105,60 +136,81 @@ A contact person related to this shipment:
 
 #### Document
 
-- `code`: The unique identifier of the document as provided by the supplier or buyer
+- `code`: The unique identifier of the document as provided by the supplier or
+  buyer
 - `revision`: The revision of the document
 - `name`: The short name of the document
 - `description`: The description of the document
 - `type`: The type of the document (e.g., General, Invoice, Packing List, etc.)
-- `objectId`: The object ID as known by the Tradecloud Object Storage, if this document is stored in Tradecloud, see also:
+- `objectId`: The object ID as known by the Tradecloud Object Storage, if this
+  document is stored in Tradecloud, see also:
 
 {% page-ref page="download-document.md" %}
 
 - `url`: The location of the document if it is not stored in Tradecloud
 - `meta`: Meta information about the shipment document
-  - `lastUpdatedAt`: ISO date and time with timezone when the shipment document was last updated in Tradecloud. A document has been added or changed if the `document.meta.lastUpdatedAt` equals the `shipment.meta.lastUpdatedAt`
+- `lastUpdatedAt`: ISO date and time with timezone when the shipment document
+was last updated in Tradecloud. A document has been added or changed if the
+`document.meta.lastUpdatedAt` equals the `shipment.meta.lastUpdatedAt`
 
 #### Purchase order terms
 
-The purchase order terms, as agreed between buyer and supplier, related to this shipment:
+The purchase order terms, as agreed between buyer and supplier, related to this
+shipment:
 
-- `incotermsCode`: The Incoterms code according to ICC [Incoterms 2020](https://iccwbo.org/business-solutions/incoterms-rules/incoterms-2020/)
-- `incoterms`: The Incoterms named place (delivery, terminal, port, or destination)
-- `paymentTermsCode`: The payment terms code as defined in the buyer's ERP system
+- `incotermsCode`: The Incoterms code according to ICC [Incoterms
+  2020](https://iccwbo.org/business-solutions/incoterms-rules/incoterms-2020/)
+- `incoterms`: The Incoterms named place (delivery, terminal, port, or
+  destination)
+- `paymentTermsCode`: The payment terms code as defined in the buyer's ERP
+  system
 - `paymentTerms`: The payment terms text as defined in the buyer's ERP system
 
 ## Load carrier
 
-A load carrier containing shipment lines. Use either the [container fields](#container-fields) or the [generic package fields](#generic-package-fields) together with [lines](#lines).
+A load carrier containing shipment lines. Use either the [container
+fields](#container-fields) or the [generic package
+fields](#generic-package-fields) together with [lines](#lines).
 
 ### Container fields
 
 When the load carrier is a container:
 
-- `containerNumber`: The BIC ISO 6346 [Container Identification Number](https://www.bic-code.org/identification-number/)
-- `containerSizeAndType`: The BIC ISO 6346 [Container Size & Type Code](https://www.bic-code.org/size-type-code/)
+- `containerNumber`: The BIC ISO 6346 [Container Identification
+  Number](https://www.bic-code.org/identification-number/)
+- `containerSizeAndType`: The BIC ISO 6346 [Container Size & Type
+  Code](https://www.bic-code.org/size-type-code/)
 
 ### Generic package fields
 
 When the load carrier is NOT a container:
 
-- `packageSSCC`: The package GS1 [Serial Shipping Container Code (SSCC)](https://www.gs1.org/standards/id-keys/sscc)
-- `packageType`: The package type. [UNECE Code List Recommendation 21](https://unece.org/trade/uncefact/cl-recommendations) is recommended
+- `packageSSCC`: The package GS1 [Serial Shipping Container Code
+  (SSCC)](https://www.gs1.org/standards/id-keys/sscc)
+- `packageType`: The package type. [UNECE Code List Recommendation
+  21](https://unece.org/trade/uncefact/cl-recommendations) is recommended
 
 ### Lines
 
-- `lines`: A list of all shipment lines loaded in this load carrier, see [Shipment line](#shipment-line)
+- `lines`: A list of all shipment lines loaded in this load carrier, see
+  [Shipment line](#shipment-line)
 
 ## Shipment line
 
-A shipment line containing identifiers, item, and supplier data including quantities. A line is added to either a shipment directly or to a load carrier.
+A shipment line containing identifiers, item, and supplier data including
+quantities. A line is added to either a shipment directly or to a load carrier.
 
-- `purchaseOrderNumber`: The mandatory related purchase order number as provided by the buyer
-- `purchaseOrderLinePosition`: The mandatory line position in the purchase order as provided by the buyer
-- `deliverySchedulePosition`: The related delivery schedule position in the purchase order line as provided by the buyer
+- `purchaseOrderNumber`: The mandatory related purchase order number as provided
+  by the buyer
+- `purchaseOrderLinePosition`: The mandatory line position in the purchase order
+  as provided by the buyer
+- `deliverySchedulePosition`: The related delivery schedule position in the
+  purchase order line as provided by the buyer
 - `item`: The item that is shipped, see [Shipment item](#shipment-item)
-- `supplierLine`: The supplier side of the shipment line, see [Supplier shipment line](#supplier-shipment-line)
-- `meta`: Meta information about the shipment line, see [Shipment line meta information](#shipment-line-meta-information)
+- `supplierLine`: The supplier side of the shipment line, see [Supplier shipment
+  line](#supplier-shipment-line)
+- `meta`: Meta information about the shipment line, see [Shipment line meta
+  information](#shipment-line-meta-information)
 
 ### Shipment item
 
@@ -167,51 +219,72 @@ The item (article, goods) being shipped:
 - `buyerItemNumber`: The item number as provided by the buyer
 - `buyerItemRevision`: The revision of the item as provided by the buyer
 - `buyerItemName`: The short name of this item as provided by the buyer
-- `supplierItemNumber`: The supplier item code or number as provided by the buyer or supplier
+- `supplierItemNumber`: The supplier item code or number as provided by the
+  buyer or supplier
 - `supplierItemRevision`: The revision (or version) as provided by the supplier
 - `supplierItemName`: The short name of this item as provided by the supplier
-- `purchaseUnitOfMeasureIso`: The 3-letter purchase unit according to ISO 80000-1 which applies to this item
+- `purchaseUnitOfMeasureIso`: The purchase unit of measure for this item, passed
+  through as-is. No standard is enforced; UN/ECE Recommendation N°20 is
+  recommended if you want a standard
 
 ### Supplier shipment line
 
 The supplier side of the shipment line:
 
-- `despatchAdviceNumber`: The mandatory unique despatch advice number as provided by the supplier
-- `despatchAdviceLinePosition`: The mandatory position in the despatch advice as provided by the supplier. The position is unique within the despatch advice and immutable
-- `despatchQuantity`: The mandatory despatch quantity of this purchase order line or delivery schedule position
-- `backorderQuantity`: The backorder quantity of this purchase order line or delivery schedule position
+- `despatchAdviceNumber`: The mandatory unique despatch advice number as
+  provided by the supplier
+- `despatchAdviceLinePosition`: The mandatory position in the despatch advice as
+  provided by the supplier. The position is unique within the despatch advice
+  and immutable
+- `despatchQuantity`: The mandatory despatch quantity of this purchase order
+  line or delivery schedule position
+- `backorderQuantity`: The backorder quantity of this purchase order line or
+  delivery schedule position
 
 ### Shipment line meta information
 
-- `lastUpdatedAt`: ISO date and time with timezone when the shipment line was last updated in Tradecloud. A line has been added or changed if the `lines.meta.lastUpdatedAt` equals the `shipment.meta.lastUpdatedAt`
+- `lastUpdatedAt`: ISO date and time with timezone when the shipment line was
+  last updated in Tradecloud. A line has been added or changed if the
+  `lines.meta.lastUpdatedAt` equals the `shipment.meta.lastUpdatedAt`
 
 ## Shipment locations
 
-The departure and destination locations together with arrival and departure date/times of a shipment:
+The departure and destination locations together with arrival and departure
+date/times of a shipment:
 
-- `departure`: The departure location and dates, see [Shipment departure](#shipment-departure)
-- `destinations`: One or more destination locations with arrival and departure date/times, see [Shipment destination](#shipment-destination)
+- `departure`: The departure location and dates, see [Shipment
+  departure](#shipment-departure)
+- `destinations`: One or more destination locations with arrival and departure
+  date/times, see [Shipment destination](#shipment-destination)
 
 ### Shipment departure
 
 A shipment departure location with ETD and ATD dates:
 
-- `location`: The departure location, see [Shipment location](#shipment-location)
+- `location`: The departure location, see [Shipment
+  location](#shipment-location)
 - `etdDate`: The Estimated Time of Departure of this shipment from this location
 - `atdDate`: The Actual Time of Departure of this shipment from this location
 
 ### Shipment destination
 
-A shipment place, port, or final destination with location, ETA time window, ATA, ETD, and ATD dates:
+A shipment place, port, or final destination with location, ETA time window,
+ATA, ETD, and ATD dates:
 
-- `location`: The location where the shipment should arrive next, see [Shipment location](#shipment-location)
+- `location`: The location where the shipment should arrive next, see [Shipment
+  location](#shipment-location)
 
-Estimated start and end date/times indicate the scheduled time window of arrival:
+Estimated start and end date/times indicate the scheduled time window of
+arrival:
 
-- `etaStartDate`: The Estimated Time of Arrival period start date of this shipment at this destination
-- `etaStartTime`: The Estimated Time of Arrival period start time of this shipment at this destination
-- `etaEndDate`: The Estimated Time of Arrival period end date of this shipment at this destination
-- `etaEndTime`: The Estimated Time of Arrival period end time of this shipment at this destination
+- `etaStartDate`: The Estimated Time of Arrival period start date of this
+  shipment at this destination
+- `etaStartTime`: The Estimated Time of Arrival period start time of this
+  shipment at this destination
+- `etaEndDate`: The Estimated Time of Arrival period end date of this shipment
+  at this destination
+- `etaEndTime`: The Estimated Time of Arrival period end time of this shipment
+  at this destination
 
 - `ataDate`: The Actual Time of Arrival of this shipment at this destination
 - `etdDate`: The Estimated Time of Departure of this shipment from this location
@@ -219,7 +292,8 @@ Estimated start and end date/times indicate the scheduled time window of arrival
 
 ## Shipment location
 
-- `locationType`: A location type according to ICC [Incoterms 2020](https://iccwbo.org/business-solutions/incoterms-rules/incoterms-2020/):
+- `locationType`: A location type according to ICC [Incoterms
+  2020](https://iccwbo.org/business-solutions/incoterms-rules/incoterms-2020/):
 
   - `AgreedPlace` (used with EXW, FCA)
   - `PortOfLoading` (used with FAS, FOB)
@@ -228,26 +302,34 @@ Estimated start and end date/times indicate the scheduled time window of arrival
   - `FinalDestination` (used with DAP, DPU, DDP)
 
 - `id`: The required identifier for the location, in context of `idScheme`
-- `idScheme`: Scheme providing context to the location identifier, like [GLN](https://www.gs1.org/standards/id-keys/gln)
-- `names`: One or more location names. It is recommended to provide at least one name
+- `idScheme`: Scheme providing context to the location identifier, like
+  [GLN](https://www.gs1.org/standards/id-keys/gln)
+- `names`: One or more location names. It is recommended to provide at least one
+  name
 - `addressLines`: One or more location address lines
 - `postalCode`: Location postal code
 - `city`: Location city
-- `countryCodeIso`: [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code
+- `countryCodeIso`: [ISO 3166-1
+  alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code
 
 ## Shipment meta information
 
-- `lastUpdatedAt`: ISO date and time with timezone when the shipment was last updated in Tradecloud, useful for polling shipments
+- `lastUpdatedAt`: ISO date and time with timezone when the shipment was last
+  updated in Tradecloud, useful for polling shipments
 - `supplierErpMeta`: The supplier's ERP meta information about this shipment
-  - `despatchAdviceErpIssueDateTime`: Local date and time when the despatch advice of this shipment was issued in the supplier's ERP system
+- `despatchAdviceErpIssueDateTime`: Local date and time when the despatch advice
+of this shipment was issued in the supplier's ERP system
 
 ## Message meta information
 
 - `messageId`: The Tradecloud identifier of this message
 - `source`: Includes meta information about the source of this message:
 
-  - `traceId`: The Tradecloud trace identifier of this message. All related messages in a flow will have the same traceId
-  - `userId`: The Tradecloud user identifier which triggered the first message in a flow
-  - `companyId`: The Tradecloud company identifier which triggered the first message in a flow
+- `traceId`: The Tradecloud trace identifier of this message. All related
+messages in a flow will have the same traceId
+- `userId`: The Tradecloud user identifier which triggered the first message in
+a flow
+- `companyId`: The Tradecloud company identifier which triggered the first
+message in a flow
 
 - `createdDateTime`: Date and time with time zone when this message was created

--- a/shipment/supplier/send-despatch-advice.md
+++ b/shipment/supplier/send-despatch-advice.md
@@ -113,7 +113,7 @@ arrival:
   * `PlaceOfDestination` (used with CPT, CIP)
   * `FinalDestination` (used with DAP, DPU, DDP)
 
-* `id`: the required identifier for the location, in context of `idSchema`
+* `id`: the required identifier for the location, in context of `idScheme`
 * `idScheme`: scheme, providing context to the location identifier. For example
   GLN
 * `names`: one or more location names. It is recommended to provide at least one

--- a/shipment/supplier/send-despatch-advice.md
+++ b/shipment/supplier/send-despatch-advice.md
@@ -6,61 +6,84 @@ description: How to send a new or updated despatch advice to Tradecloud
 
 ## Despatch advice process
 
-As supplier you can send either a **new or updated** despatch advice to Tradecloud.
+As supplier you can send either a **new or updated** despatch advice to
+Tradecloud.
 
 {% hint style="info" %}
-When a purchase order number is provided, but the item is not or partly provided, the item in the despatch advice will be enriched if Tradecloud can find the purchase order.
+When a purchase order number is provided, but the item is not or partly
+provided, the item in the despatch advice will be enriched if Tradecloud can
+find the purchase order.
 {% endhint %}
 
-## Endpoint 
+## Endpoint
 
 {% hint style="warning" %}
 The shipment module is under development. The API and documentation may change.
 {% endhint %}
 
-Use the [Send despatch advice](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/supplier-endpoints/sendDespatchAdviceBySupplierRoute) to send a despatch advice to Tradecloud.
+Use the [Send despatch
+advice](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/supplier-endpoints/sendDespatchAdviceBySupplierRoute)
+to send a despatch advice to Tradecloud.
 
 {% hint style="info" %}
-When sending a despatch advice the provided buyer account number will be verified.
+When sending a despatch advice the provided buyer account number will be
+verified.
 {% endhint %}
 
-# Despatch advice
+## Despatch advice
 
-* `header`: the despatch advice header, see [Despatch advice header](#despatch-advice-header)
-* `lines`: the despatch advice lines, see [Despatch advice line](#despatch-advice-line). The total number of lines is limited to 500 lines per shipment.
-* `erpIssueDateTime`: local date and time at which the despatch advice of this shipment was issued in the supplier's ERP system
+* `header`: the despatch advice header, see [Despatch advice
+  header](#despatch-advice-header)
+* `lines`: the despatch advice lines, see [Despatch advice
+  line](#despatch-advice-line). The total number of lines is limited to 500
+  lines per shipment.
+* `erpIssueDateTime`: local date and time at which the despatch advice of this
+  shipment was issued in the supplier's ERP system
 
 ## Despatch advice header
 
-* `supplierCompanyId`: the optional Tradecloud company identifier of the supplier. You only have to provide a companyId when your integration user account has authorization for multiple companies. 
-* `buyerAccountNumber`: the buyer account code or number as known in the supplier's ERP system
-* `despatchAdviceNumber`: the unique despatch advice number as provided by the supplier
+* `supplierCompanyId`: the optional Tradecloud company identifier of the
+  supplier. You only have to provide a companyId when your integration user
+  account has authorization for multiple companies.
+* `buyerAccountNumber`: the buyer account code or number as known in the
+  supplier's ERP system
+* `despatchAdviceNumber`: the unique despatch advice number as provided by the
+  supplier
 * `shipment`: the shipment related to this despatch advice:
 
 ## Despatch advice shipment
 
-* `shipmentNumber`: the related shipment number as known in the supplier's ERP system.
+* `shipmentNumber`: the related shipment number as known in the supplier's ERP
+  system.
 
 {% hint style="warning" %}
 The `shipmentNumber` must not contain whitespace characters.
 {% endhint %}
 
-* `shipmentCompanyName`: the shipment company name, like the carrier or courier name.
-* `trackingNumber`: the tracking number of the shipment as provided by the carrier or courier
-* `departure`: the departure location and date of a shipment, see [Shipment departure ](#shipment-departure)
-* `destination`: the next destination location and scheduled arrival date/time, see [Shipment next destination](#shipment-next-destination)
-* `finalDestination`: the final destination location and scheduled arrival date/time, see [Shipment final destination](#shipment-final-destination)
+* `shipmentCompanyName`: the shipment company name, like the carrier or courier
+  name.
+* `trackingNumber`: the tracking number of the shipment as provided by the
+  carrier or courier
+* `departure`: the departure location and date of a shipment, see [Shipment
+  departure](#shipment-departure)
+* `destination`: the next destination location and scheduled arrival date/time,
+  see [Shipment next destination](#shipment-next-destination)
+* `finalDestination`: the final destination location and scheduled arrival
+  date/time, see [Shipment final destination](#shipment-final-destination)
 
-### Shipment departure 
+### Shipment departure
 
-* `location`: the departure location, see [Shipment location](#shipment-location)
+* `location`: the departure location, see [Shipment
+  location](#shipment-location)
 * `actualDate`: the actual departure local date
 
-### Shipment next destination 
+### Shipment next destination
 
-* `location`: the location where the shipment should arrive next, see [Shipment location](#shipment-location)
+* `location`: the location where the shipment should arrive next, see [Shipment
+  location](#shipment-location)
 
-Scheduled start and end date/times indicate the scheduled time window of arrival:
+Scheduled start and end date/times indicate the scheduled time window of
+arrival:
 
 * `scheduledStartDate`: start local date of the arrival time window
 * `scheduledStartTime`: start local time of the arrival time window
@@ -69,11 +92,13 @@ Scheduled start and end date/times indicate the scheduled time window of arrival
 
 ### Shipment final destination
 
-* `location`: the location where the shipment should arrive finally, see [Shipment location](#shipment-location)
+* `location`: the location where the shipment should arrive finally, see
+  [Shipment location](#shipment-location)
 
-Scheduled start and end date/times indicate the scheduled time window of arrival:
+Scheduled start and end date/times indicate the scheduled time window of
+arrival:
 
-* `scheduledStartDate`: start local date of the arrival time window. 
+* `scheduledStartDate`: start local date of the arrival time window.
 * `scheduledStartTime`: start local time of the arrival time window.
 * `scheduledEndDate`: end local date of the arrival time window.
 * `scheduledEndTime`: end local time of the arrival time window.
@@ -89,8 +114,10 @@ Scheduled start and end date/times indicate the scheduled time window of arrival
   * `FinalDestination` (used with DAP, DPU, DDP)
 
 * `id`: the required identifier for the location, in context of `idSchema`
-* `idScheme`: scheme, providing context to the location identifier. For example GLN
-* `names`: one or more location names. It is recommended to provide at least one name.
+* `idScheme`: scheme, providing context to the location identifier. For example
+  GLN
+* `names`: one or more location names. It is recommended to provide at least one
+  name.
 * `addressLines`: one or more location address lines
 * `postalCode`: location postal code
 * `city`: location city
@@ -98,19 +125,30 @@ Scheduled start and end date/times indicate the scheduled time window of arrival
 
 ## Despatch advice line
 
-* `despatchAdviceLinePosition` the position in the despatch advice as provided by the supplier. The position is unique within the despatch advice and immutable.
-* `purchaseOrderNumber`: the related purchase order number as provided by the buyer
-* `purchaseOrderLinePosition`: the line position in the purchase order as provided by the buyer
-* `item`: the item that is shipped, see [Shipment item](#shipment-item)
-* `despatchQuantity` the despatched quantity of this purchase order line or delivery schedule position.
-* `backorderQuantity`: the backorder quantity of this purchase order line or delivery schedule position.
+* `despatchAdviceLinePosition` the position in the despatch advice as provided
+  by the supplier. The position is unique within the despatch advice and
+  immutable.
+* `purchaseOrderNumber`: the related purchase order number as provided by the
+  buyer
+* `purchaseOrderLinePosition`: the line position in the purchase order as
+  provided by the buyer
+* `item`: the item that is shipped, see [Despatch advice item](#despatch-advice-item)
+* `despatchQuantity` the despatched quantity of this purchase order line or
+  delivery schedule position.
+* `backorderQuantity`: the backorder quantity of this purchase order line or
+  delivery schedule position.
 
 ### Despatch advice item
 
 * `buyerItemNumber`: the required item code or number as provided by the buyer
 * `buyerItemRevision`: the revision of the item as provided by the buyer
 * `buyerItemName`: the short name of this item as provided by the buyer
-* `supplierItemNumber`: the supplier item code or number as known in the supplier's ERP system
-* `supplierItemRevision`: the revision (or version) as known in the supplier's ERP system
-* `supplierItemName`: the short name of this item as known in the supplier's ERP system
-* `purchaseUnitOfMeasureIso`: the the 3-letter purchase unit according to ISO 80000-1 which applies to this item
+* `supplierItemNumber`: the supplier item code or number as known in the
+  supplier's ERP system
+* `supplierItemRevision`: the revision (or version) as known in the supplier's
+  ERP system
+* `supplierItemName`: the short name of this item as known in the supplier's ERP
+  system
+* `purchaseUnitOfMeasureIso`: the purchase unit of measure for this item, passed
+  through as-is. No standard is enforced; UN/ECE Recommendation N°20 is
+  recommended if you want a standard


### PR DESCRIPTION
## Summary

- Add a **Units of Measure** section to `api/standards.md` explaining as-is handling, optional UN/ECE Recommendation N°20, and the three exceptions (portal translation, SCSN, equivalence comparison)
- Rewrite unit-of-measure field descriptions across order, shipment, and forecast API manual pages to drop ISO 80000-1 claims
- Fix markdownlint MD013 line-length issues in all touched pages

## Test plan

- [ ] `npx markdownlint-cli2` on touched markdown files passes
- [ ] GitBook preview: Units of Measure section reads correctly
- [ ] No endpoint, field name, or payload changes

## Related

- Jira: [TC-11065](https://tradecloud.atlassian.net/browse/TC-11065)
- Companion PRs: `tradecloud-microservices`, `tradecloud-connectors-scala` (same branch name)

[TC-11065]: https://tradecloud.atlassian.net/browse/TC-11065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Updated API standards documentation with improved Markdown formatting and clearer structure across authentication, date/time, JSON, and protocol guidance sections.  
- Refined forecast and order documentation with clearer hint callouts, guidance placement, and corrected unit-of-measure semantics.  
- Improved shipment and despatch advice payload/documentation formatting for consistency and readability.  
- Standardized unit-of-measure field wording to “passed through as-is” (no enforced standard) and recommended UN/ECE Recommendation N°20 for users wanting standardization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->