### PR TITLE
docs(ftp): [TC-11075] republish SFTP pages

### DIFF
--- a/connectors/sftp/README.md
+++ b/connectors/sftp/README.md
@@ -4,12 +4,14 @@ description: 'EDIFACT, CSV and custom file formats over secure SFTP server hoste
 
 # SFTP Connectors
 
-Tradecloud provides secure file-based integration through SFTP connectors, enabling seamless data exchange using industry-standard file formats for organizations that prefer batch processing or have legacy systems.
+Tradecloud provides secure file-based integration through SFTP connectors,
+enabling seamless data exchange using industry-standard file formats for
+organizations that prefer batch processing or have legacy systems.
 
 ## Available Connectors
 
 | Connector | Format | Use Case |
-|-----------|--------|----------|
+| --- | --- | --- |
 | **[CSV SFTP Connector](csv.md)** | RFC 4180 CSV | Custom CSV formats for flexible data exchange |
 | **[EDIFACT SFTP Connector](edifact.md)** | UN/EDIFACT D.96A | Standardized EDI messaging for supply chain |
 
@@ -18,7 +20,7 @@ Tradecloud provides secure file-based integration through SFTP connectors, enabl
 ### Server Information
 
 | Environment | Hostname | Protocol | Port |
-|-------------|----------|----------|------|
+| --- | --- | --- | --- |
 | **Acceptance** | `ftp.accp.tradecloud1.com` | SFTP | 22 |
 | **Production** | `ftp.tradecloud1.com` | SFTP | 22 |
 
@@ -30,7 +32,8 @@ Tradecloud provides secure file-based integration through SFTP connectors, enabl
 - **Requirements**: SFTP client and outbound internet access
 
 {% hint style="info" %}
-FTP and FTPS protocols are **not supported** for security reasons. Only SFTP connections are accepted.
+FTP and FTPS protocols are **not supported** for security reasons. Only SFTP
+connections are accepted.
 {% endhint %}
 
 ## Directory Structure
@@ -39,7 +42,7 @@ Each customer has a dedicated folder structure for organized file management:
 
 ```shell
 📁 /order                    # Incoming orders
-📁 /order_change             # Order modifications  
+📁 /order_change             # Order modifications
 📁 /order_response           # Order confirmations
 📁 /despatch_advice          # Shipment notifications
 📁 /receipt_advice           # Goods receipt confirmations
@@ -63,7 +66,10 @@ Each customer has a dedicated folder structure for organized file management:
 4. **Archive** - Successfully processed files are moved to archive
 
 {% hint style="warning" %}
-**File Permissions**: Use `0664` permissions when uploading files. This is required per the [SFTP specification](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-7.6) and ensures proper file processing.
+**File Permissions**: Use `0664` permissions when uploading files. This is
+required per the
+[SFTP specification](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-7.6)
+and ensures proper file processing.
 {% endhint %}
 
 ### Downloading Files from Tradecloud
@@ -86,7 +92,7 @@ Each customer has a dedicated folder structure for organized file management:
 
 ## Getting Started
 
-1. **Contact Support** - Request FTP access credentials from [support@tradecloud1.com](mailto:support@tradecloud1.com)
+1. **Contact Support** - Request SFTP access credentials from [support@tradecloud1.com](mailto:support@tradecloud1.com)
 2. **Choose Format** - Select CSV or EDIFACT based on your requirements
 3. **Configure Client** - Set up your SFTP client with provided credentials
 4. **Test Integration** - Start with acceptance environment before production

--- a/connectors/sftp/csv.md
+++ b/connectors/sftp/csv.md
@@ -4,7 +4,9 @@ description: 'Custom CSV file integration using RFC 4180 format over secure SFTP
 
 # CSV SFTP Connector
 
-The CSV SFTP Connector enables flexible data exchange using custom CSV (Comma-Separated Values) formats, ideal for organizations with specific data structure requirements or legacy systems that work best with tabular data.
+The CSV SFTP Connector enables flexible data exchange using custom CSV
+(Comma-Separated Values) formats, ideal for organizations with specific data
+structure requirements or legacy systems that work best with tabular data.
 
 ## Overview
 
@@ -18,8 +20,8 @@ Perfect for businesses that need:
 ## Technical Specifications
 
 | Specification | Details |
-|---------------|---------|
-| **Data Format** | [RFC 4180](https://tools.ietf.org/html/rfc4180) Compliant CSV |
+| --------------- | --------- |
+| **Data Format** | [RFC 4180](https://tools.ietf.org/html/rfc4180)-compliant CSV |
 | **Character Encoding** | UTF-8 |
 | **Field Delimiter** | Comma (`,`) |
 | **Text Qualifier** | Double quote (`"`) |
@@ -30,7 +32,7 @@ Perfect for businesses that need:
 The CSV connector supports all core business documents:
 
 - **Orders** - Purchase orders and order updates
-- **Order Responses** - Supplier confirmations and modifications  
+- **Order Responses** - Supplier confirmations and modifications
 - **Despatch Advice** - Shipment notifications with tracking details
 - **Receipt Advice** - Goods receipt confirmations from buyers
 
@@ -45,7 +47,9 @@ Each CSV implementation is **custom-designed** to match your specific:
 
 ## Connection Details
 
-- **Transport Protocol**: [SFTP](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13) (SSH File Transfer Protocol)
+- **Transport Protocol**:
+  [SFTP](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13)
+  (SSH File Transfer Protocol)
 - **Server Location**: Tradecloud-hosted secure SFTP server
 - **Client Requirements**: SFTP client software and outbound internet access
 - **Security**: Encryption for all file transfers
@@ -55,7 +59,7 @@ Each CSV implementation is **custom-designed** to match your specific:
 The CSV SFTP Connector is available through our partner **Supplydrive**, who provides:
 
 - Custom CSV format design and mapping
-- Implementation and testing support  
+- Implementation and testing support
 - Ongoing maintenance and support
 - Integration expertise and best practices
 

--- a/connectors/sftp/edifact.md
+++ b/connectors/sftp/edifact.md
@@ -4,7 +4,9 @@ description: 'UN/EDIFACT D.96A standard messaging over secure SFTP for supply ch
 
 # EDIFACT SFTP Connector
 
-The EDIFACT SFTP Connector provides standardized Electronic Data Interchange (EDI) messaging using the internationally recognized UN/EDIFACT D.96A format, ensuring seamless interoperability with trading partners worldwide.
+The EDIFACT SFTP Connector provides standardized Electronic Data Interchange
+(EDI) messaging using the internationally recognized UN/EDIFACT D.96A format,
+ensuring seamless interoperability with trading partners worldwide.
 
 ## Overview
 
@@ -18,7 +20,7 @@ Ideal for organizations that require:
 ## Technical Specifications
 
 | Specification | Details |
-|---------------|---------|
+| --------------- | --------- |
 | **EDI Standard** | [UN/EDIFACT D.96A](https://unece.org/DAM/trade/untdid/d96a/d96a.zip) |
 | **Character Set** | UNOC (ISO 8859-1) |
 | **Transport Protocol** | [SFTP](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13) |
@@ -29,7 +31,7 @@ Ideal for organizations that require:
 The EDIFACT connector supports essential supply chain documents:
 
 | Message Type | EDI Code | Purpose |
-|--------------|----------|---------|
+| -------------- | ---------- | --------- |
 | **Purchase Orders** | `ORDERS` | New purchase orders and requirements |
 | **Order Changes** | `ORDCHG` | Modifications to existing orders |
 | **Order Responses** | `ORDRSP` | Supplier confirmations and acknowledgments |
@@ -41,7 +43,7 @@ The EDIFACT connector supports essential supply chain documents:
 All messages comply with UN/EDIFACT D.96A specifications:
 
 - **Message structure** follows standard segment definitions
-- **Data elements** use standard codes and formats  
+- **Data elements** use standard codes and formats
 - **Validation rules** ensure data integrity and compliance
 - **Documentation** available in [official UN/EDIFACT D.96A package](https://unece.org/DAM/trade/untdid/d96a/d96a.zip)
 
@@ -66,5 +68,5 @@ The EDIFACT SFTP Connector is available through our partner **Supplydrive**, pro
 1. **Evaluate Readiness** - Assess your EDI requirements and system capabilities
 2. **Partner Consultation** - Contact Supplydrive for implementation planning
 3. **Message Design** - Configure EDIFACT message types and trading partner setup
-4. **Testing Phase** - Validate message exchange in acceptance environment  
+4. **Testing Phase** - Validate message exchange in acceptance environment
 5. **Production Deployment** - Go live with monitoring and ongoing support


### PR DESCRIPTION
## Summary

- Republish the SFTP connector pages (`connectors/sftp/README.md`, `csv.md`, `edifact.md`) in GitBook, where they had disappeared. Committing a change to these pages triggers GitBook to re-index and re-publish them.
- While touching the pages, apply small quality fixes:
  - Grammar/consistency: "Request **SFTP** access credentials" (was FTP, which is explicitly unsupported), "RFC 4180**-compliant** CSV".
  - Removed trailing whitespace.
  - Reflowed prose to 80 columns and normalised tables to satisfy `markdownlint` strictly for these three pages.

## Test plan

- [ ] `markdownlint connectors/sftp/{README,csv,edifact}.md` passes (verified locally, exit 0)
- [ ] Confirm the three SFTP pages are visible again in the published GitBook after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed SFTP connector docs for cleaner formatting and improved readability across overview, tables, and setup sections.
  * Corrected the getting-started instructions to request **SFTP** access credentials.
  * Standardized whitespace, line wrapping, and table alignment in the SFTP CSV and EDIFACT documentation.
  * Kept all connector behavior and content meaning unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->