### PR TITLE
docs: [TC-11017] delivery history replace endpoint and webhook events

### DIFF
--- a/connectors/webhooks/order-events.md
+++ b/connectors/webhooks/order-events.md
@@ -140,6 +140,8 @@ Both buyer and supplier can update the logistics process.
 | `OrderLinesShippedByBuyer`                             | Order lines are marked as shipped by the buyer                 |
 | `OrderLinesMarkedAsDeliveredByBuyer`                   | Order lines are marked as delivered by the buyer               |
 | `OrderLinesMarkedAsDeliveredBySupplier`                | Order lines are marked as delivered by the supplier            |
+| `OrderLinesDeliveryHistoryAppendedByBuyer`             | Order lines delivery history is appended by the buyer          |
+| `OrderLinesDeliveryHistorySetByBuyer`                  | Order lines delivery history is replaced by the buyer          |
 | `OrderLinesDeliveryScheduleLogisticsUpdatedByBuyer`    | Delivery schedule logistics fields are updated by the buyer    |
 | `OrderLinesDeliveryScheduleLogisticsUpdatedBySupplier` | Delivery schedule logistics fields are updated by the supplier |
 

--- a/order/buyer/receive-goods.md
+++ b/order/buyer/receive-goods.md
@@ -15,7 +15,7 @@ The delivery history contains the actual physical deliveries. With the actual de
 
 The actual delivery history is matched against the planned delivery schedule **by date and quantity**, not by delivery line position — `deliveryHistory.position` and `deliverySchedule.position` do not have to use the same values.
 
-There are two ways to send the delivery history to Tradecloud:
+There are three ways to send the delivery history to Tradecloud:
 
 ### Send the delivery history by updating an order using the `/order` endpoint
 
@@ -35,6 +35,21 @@ Before adding a delivery to an order, the order must have been sent to Tradeclou
 
 {% hint style="warning" %}
 The `/order/deliveries` endpoint is not supported when using the single delivery feature.
+Let [support](../support.md) know when you need this endpoint for single delivery.
+{% endhint %}
+
+### Replace the delivery history using the `/api-connector/order/deliveryHistory` endpoint
+
+Replace the delivery history for one or multiple existing order lines using the [Send order delivery history](https://swagger-ui.accp.tradecloud1.com/?url=https://api.accp.tradecloud1.com/v2/api-connector/specs.yaml#/buyer-endpoints/sendOrderDeliveryHistoryByBuyer) endpoint. Unlike `/order/deliveries`, which appends deliveries, this endpoint replaces the delivery history per order line with the deliveries in the request.
+
+Only the lines present in the request are affected; lines not included are left untouched. To clear the delivery history of a line, send that line with an empty `deliveryHistory` array. As with the other methods, the delivery history is matched against the planned delivery schedule by date and quantity.
+
+{% hint style="warning" %}
+Before replacing the delivery history of an order, the order must have been sent to Tradecloud first.
+{% endhint %}
+
+{% hint style="warning" %}
+The `/order/deliveryHistory` endpoint is not supported when using the single delivery feature.
 Let [support](../support.md) know when you need this endpoint for single delivery.
 {% endhint %}
 


### PR DESCRIPTION
## Summary

Public API documentation for [TC-11017](https://tradecloud.atlassian.net/browse/TC-11017): the buyer `POST /order/deliveryHistory` endpoint that **replaces** per-line delivery history (sibling to the append-only `POST /order/deliveries`).

- `order/buyer/receive-goods.md`: add the delivery history replace endpoint as a third way to announce received goods, contrasting replace vs append semantics and noting it is not supported with the single-delivery feature.
- `connectors/webhooks/order-events.md`: add `OrderLinesDeliveryHistorySetByBuyer` (replace) to the "Order lines logistics" events, and also add the previously undocumented `OrderLinesDeliveryHistoryAppendedByBuyer` (append) which the order webhook already forwards.

## Test plan

- [ ] Pages render in GitBook without broken links or formatting issues.
- [ ] Event names match the order webhook OpenAPI spec in tradecloud-connectors-scala.

Made with [Cursor](https://cursor.com)

[TC-11017]: https://tradecloud.atlassian.net/browse/TC-11017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded order delivery guidance to cover a third way of handling delivery history.
  * Added details on replacing delivery history for specific order lines, including how it differs from appending updates.
  * Clarified that only included lines are affected, how to clear history, and how delivery matching works by date and quantity.
  * Added notes about required prerequisites and current feature limitations.
  * Updated webhook documentation with two additional buyer delivery-history events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->